### PR TITLE
Sign release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
 
     permissions:
       contents: write
+      id-token: write
       packages: write
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: v2.1.1
+          cosign-release: v2.2.0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,5 +57,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
-          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-          COSIGN_PWD: ${{ secrets.COSIGN_PWD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,13 @@ jobs:
       packages: write
 
     steps:
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -43,3 +50,4 @@ jobs:
           args: release --clean --timeout=60m --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,14 @@ jobs:
       packages: write
 
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Import GPG key
         id: gpg
         uses: crazy-max/ghaction-import-gpg@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Import GPG key
-        id: gpg
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: v2.1.1
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -59,3 +64,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_PWD: ${{ secrets.COSIGN_PWD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,3 @@ jobs:
           args: release --clean --timeout=60m --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -163,6 +163,10 @@ docker_manifests:
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
 
+signs:
+  - artifacts: checksum
+    args: [ "--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}" ]
+
 snapshot:
   name_template: "{{ .Version }}-next"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,14 +132,7 @@ dockers:
       - "ghcr.io/opentffoundation/opentf:{{ .Version }}-386"
 
 docker_manifests:
-  - name_template: ghcr.io/opentffoundation/opentf:v{{ .Version }}
-    image_templates:
-      - ghcr.io/opentffoundation/opentf:{{ .Version }}-amd64
-      - ghcr.io/opentffoundation/opentf:{{ .Version }}-arm64
-      - ghcr.io/opentffoundation/opentf:{{ .Version }}-arm
-      - ghcr.io/opentffoundation/opentf:{{ .Version }}-386
-
-  - name_template: ghcr.io/opentffoundation/opentf:{{ .Major }}
+  - name_template: ghcr.io/opentffoundation/opentf:{{ .Version }}
     image_templates:
       - ghcr.io/opentffoundation/opentf:{{ .Version }}-amd64
       - ghcr.io/opentffoundation/opentf:{{ .Version }}-arm64
@@ -147,6 +140,13 @@ docker_manifests:
       - ghcr.io/opentffoundation/opentf:{{ .Version }}-386
 
   - name_template: ghcr.io/opentffoundation/opentf:{{ .Major }}.{{ .Minor }}
+    image_templates:
+      - ghcr.io/opentffoundation/opentf:{{ .Version }}-amd64
+      - ghcr.io/opentffoundation/opentf:{{ .Version }}-arm64
+      - ghcr.io/opentffoundation/opentf:{{ .Version }}-arm
+      - ghcr.io/opentffoundation/opentf:{{ .Version }}-386
+
+  - name_template: ghcr.io/opentffoundation/opentf:{{ .Major }}
     image_templates:
       - ghcr.io/opentffoundation/opentf:{{ .Version }}-amd64
       - ghcr.io/opentffoundation/opentf:{{ .Version }}-arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,6 +167,11 @@ signs:
   - artifacts: checksum
     args: [ "--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}" ]
 
+docker_signs:
+  - artifacts: all
+    args: ["sign", "--key=env://COSIGN_KEY", "${artifact}@${digest}", "--yes"]
+    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+
 snapshot:
   name_template: "{{ .Version }}-next"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -165,7 +165,9 @@ checksum:
 
 signs:
   - artifacts: checksum
-    args: [ "--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}" ]
+    cmd: cosign
+    args: ["sign-blob", "--key=env://COSIGN_KEY", "--output-signature=${signature}", "${artifact}", "--yes"]
+    stdin: "{{ .Env.COSIGN_PASSWORD }}"
 
 docker_signs:
   - artifacts: all

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,12 +167,12 @@ signs:
   - artifacts: checksum
     cmd: cosign
     args: ["sign-blob", "--key=env://COSIGN_KEY", "--output-signature=${signature}", "${artifact}", "--yes"]
-    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+    stdin: "{{ .Env.COSIGN_PWD }}"
 
 docker_signs:
   - artifacts: all
     args: ["sign", "--key=env://COSIGN_KEY", "${artifact}@${digest}", "--yes"]
-    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+    stdin: "{{ .Env.COSIGN_PWD }}"
 
 snapshot:
   name_template: "{{ .Version }}-next"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,12 +167,10 @@ signs:
   - artifacts: checksum
     cmd: cosign
     certificate: "${artifact}.pem"
-    output: true
     args: ["sign-blob", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
 
 docker_signs:
   - artifacts: all
-    output: true
     args: ["sign", "${artifact}@${digest}", "--yes"]
 
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -166,13 +166,14 @@ checksum:
 signs:
   - artifacts: checksum
     cmd: cosign
-    args: ["sign-blob", "--key=env://COSIGN_KEY", "--output-signature=${signature}", "${artifact}", "--yes"]
-    stdin: "{{ .Env.COSIGN_PWD }}"
+    certificate: "${artifact}.pem"
+    output: true
+    args: ["sign-blob", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
 
 docker_signs:
   - artifacts: all
-    args: ["sign", "--key=env://COSIGN_KEY", "${artifact}@${digest}", "--yes"]
-    stdin: "{{ .Env.COSIGN_PWD }}"
+    output: true
+    args: ["sign", "${artifact}@${digest}", "--yes"]
 
 snapshot:
   name_template: "{{ .Version }}-next"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,11 +167,11 @@ signs:
   - artifacts: checksum
     cmd: cosign
     certificate: "${artifact}.pem"
-    args: ["sign-blob", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
+    args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
 
 docker_signs:
   - artifacts: all
-    args: ["sign", "${artifact}@${digest}", "--yes"]
+    args: ["sign", "--oidc-issuer=https://token.actions.githubusercontent.com", "${artifact}@${digest}", "--yes"]
 
 snapshot:
   name_template: "{{ .Version }}-next"


### PR DESCRIPTION
Fixes #180 

Use `cosign` for OIDC-based signing of the release artifacts

- Sign the artifact checksums
- Sign the docker iamges

## Target Release

1.6.0

