### PR TITLE
Fix `opentf test` crash on nil output

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -152,6 +152,10 @@ func TestTest(t *testing.T) {
 			expected: "3 passed, 0 failed.",
 			code:     0,
 		},
+		"null_output": {
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
@@ -225,6 +229,11 @@ func TestTest_Broken_Full_Output(t *testing.T) {
 		},
 		"broken_wrong_block_check": {
 			expected: "Blocks of type \"check\" are not expected here.",
+			code:     1,
+		},
+		"not_exists_output": {
+			expected: "Error: Reference to undeclared output value",
+			args:     []string{"-no-color"},
 			code:     1,
 		},
 		"refresh_conflicting_config": {

--- a/internal/command/testdata/test/not_exists_output/main.tf
+++ b/internal/command/testdata/test/not_exists_output/main.tf
@@ -1,0 +1,2 @@
+resource "test_resource" "resource" {
+}

--- a/internal/command/testdata/test/not_exists_output/main.tftest.hcl
+++ b/internal/command/testdata/test/not_exists_output/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "not_exists" {
+  assert {
+    condition = output.something_that_does_not_exists == null
+    error_message = "Should fail for Reference to undeclared output value"
+  }
+}

--- a/internal/command/testdata/test/not_exists_output/main.tftest.hcl
+++ b/internal/command/testdata/test/not_exists_output/main.tftest.hcl
@@ -1,6 +1,6 @@
 run "not_exists" {
   assert {
-    condition = output.something_that_does_not_exists == null
+    condition = output.something_that_does_not_exist == null
     error_message = "Should fail for Reference to undeclared output value"
   }
 }

--- a/internal/command/testdata/test/null_output/main.tf
+++ b/internal/command/testdata/test/null_output/main.tf
@@ -1,0 +1,3 @@
+output "my_null_output" {
+  value = null
+}

--- a/internal/command/testdata/test/null_output/main.tftest.hcl
+++ b/internal/command/testdata/test/null_output/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "null" {
+  assert {
+    condition = output.my_null_output == null
+    error_message = "Should work"
+  }
+}

--- a/internal/opentf/evaluate.go
+++ b/internal/opentf/evaluate.go
@@ -974,7 +974,6 @@ func (d *evaluationStateData) GetOutput(addr addrs.OutputValue, rng tfdiags.Sour
 	}
 
 	output := d.Evaluator.State.OutputValue(addr.Absolute(d.ModulePath))
-	log.Printf("[ERROR] eranelbazdebug the output value of %q is %+v", addr.Absolute(d.ModulePath), output)
 	// https://github.com/opentffoundation/opentf/issues/257
 	// If the output is null, we do not store it to the state /internal/opentf/node_output.go#L592-L596
 	// Then OpenTF test crash to evaluate for invalid memory address or nil pointer dereference

--- a/internal/opentf/evaluate.go
+++ b/internal/opentf/evaluate.go
@@ -974,9 +974,10 @@ func (d *evaluationStateData) GetOutput(addr addrs.OutputValue, rng tfdiags.Sour
 	}
 
 	output := d.Evaluator.State.OutputValue(addr.Absolute(d.ModulePath))
+
 	// https://github.com/opentffoundation/opentf/issues/257
-	// If the output is null, we do not store it to the state /internal/opentf/node_output.go#L592-L596
-	// Then OpenTF test crash to evaluate for invalid memory address or nil pointer dereference
+	// If the output is null - it does not serialize as part of the node_output state https://github.com/opentffoundation/opentf/blob/4b623c56ffe9e6c1dc345e54470b71b0f261297a/internal/opentf/node_output.go#L592-L596
+	// In such a case, we should simply return a nil value because OpenTF test crash to evaluate for invalid memory address or nil pointer dereference
 	if output == nil {
 		return cty.NilVal, diags
 	} else {


### PR DESCRIPTION
Fixes #257

Since OpenTF does not store `nil` outputs in it's state we fail to get the value.
Added a check of `if output == nil` and if true returning `cty.NilVal` 

Added relevant tests - 
- `opentf test` does not crash for `null` outputs
- Made sure we don't some how pass undeclared outputs and set them as `null`



## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0-alpha

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `opentf test` does not crash for `null` outputs
