### PR TITLE
Fix link in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ The `local` backend finally calls an appropriate method on that context to
 begin execution of the relevant command, such as
 [`Plan`](https://pkg.go.dev/github.com/placeholderplaceholderplaceholder/opentf/internal/opentf#Context.Plan)
 or
-[`Apply`](), which in turn constructs a graph using a _graph builder_,
+[`Apply`](https://pkg.go.dev/github.com/placeholderplaceholderplaceholder/opentf/internal/opentf#Context.Apply), which in turn constructs a graph using a _graph builder_,
 described in a later section.
 
 ## Configuration Loader


### PR DESCRIPTION

Fixes N/A

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Add missing "link" to `docs/architecture.md` which would fix parsing issue we have in an internal project