### PR TITLE
chore: use correct organization in go.mod module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/placeholderplaceholderplaceholder/opentf
+module github.com/opentffoundation/opentf
 
 require (
 	cloud.google.com/go/kms v1.10.1


### PR DESCRIPTION
For some reason the `go.mod` still has a placeholder name in the module name.
I don't know if it's intended for now but it makes it impossible to just `go run github.com/opentffoundation/opentf@main` the project for easy testing.