### PR TITLE
chore: ignore /opentf binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ website/node_modules
 *.test
 *.iml
 
-/terraform
+/opentf
 
 website/vendor
 vendor/


### PR DESCRIPTION
This allows to avoid committing the `go build` output by mistake.