### PR TITLE
Require hostname for cloud/remote backends and login/logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.6.0 (Unreleased)
 
+UPGRADE NOTES:
+* The `cloud` and `remote` backends will no longer default to `app.terraform.io` hostname and will require the hostname to be explicitly specified ([#291](https://github.com/opentffoundation/opentf/pull/291));
+* The `login` and `logout` commands will no longer default to `app.terraform.io` hostname and will require the hostname to be explicitly provided as a command-line argument ([#291](https://github.com/opentffoundation/opentf/pull/291));
+
 NEW FEATURES:
 * `opentf test`: The previously experimental `opentf test` command has been moved out of experimental. This comes with a significant change in how OpenTF tests are written and executed.
 

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -177,7 +177,7 @@ func TestRemote_versionConstraints(t *testing.T) {
 	}{
 		"compatible version": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.NullVal(cty.String),
+				"hostname":     cty.StringVal("app.terraform.io"),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -189,7 +189,7 @@ func TestRemote_versionConstraints(t *testing.T) {
 		},
 		"version too old": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.NullVal(cty.String),
+				"hostname":     cty.StringVal("app.terraform.io"),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -202,7 +202,7 @@ func TestRemote_versionConstraints(t *testing.T) {
 		},
 		"version too new": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.NullVal(cty.String),
+				"hostname":     cty.StringVal("app.terraform.io"),
 				"organization": cty.StringVal("hashicorp"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -743,7 +743,7 @@ func TestRemote_ServiceDiscoveryAliases(t *testing.T) {
 	b := New(testDisco(s))
 
 	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String), // Forces aliasing to test server
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -50,7 +50,7 @@ func TestRemote_config(t *testing.T) {
 	}{
 		"with_a_nonexisting_organization": {
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.NullVal(cty.String),
+				"hostname":     cty.StringVal("app.terraform.io"),
 				"organization": cty.StringVal("nonexisting"),
 				"token":        cty.NullVal(cty.String),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -59,6 +59,18 @@ func TestRemote_config(t *testing.T) {
 				}),
 			}),
 			confErr: "organization \"nonexisting\" at host app.terraform.io not found",
+		},
+		"with_a_missing_hostname": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"hostname":     cty.NullVal(cty.String),
+				"organization": cty.StringVal("oracle"),
+				"token":        cty.NullVal(cty.String),
+				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name":   cty.StringVal("prod"),
+					"prefix": cty.NullVal(cty.String),
+				}),
+			}),
+			confErr: `Hostname is required for the remote backend`,
 		},
 		"with_an_unknown_host": {
 			config: cty.ObjectVal(map[string]cty.Value{

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	tfeHost  = svchost.Hostname(defaultHostname)
+	tfeHost  = svchost.Hostname("app.terraform.io")
 	credsSrc = auth.StaticCredentialsSource(map[svchost.Hostname]map[string]interface{}{
 		tfeHost: {"token": testCred},
 	})
@@ -297,7 +297,7 @@ func testDisco(s *httptest.Server) *disco.Disco {
 	d := disco.NewWithCredentialsSource(credsSrc)
 	d.SetUserAgent(httpclient.OpenTfUserAgent(version.String()))
 
-	d.ForceHostServices(svchost.Hostname(defaultHostname), services)
+	d.ForceHostServices(svchost.Hostname("app.terraform.io"), services)
 	d.ForceHostServices(svchost.Hostname("localhost"), services)
 	return d
 }

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -70,7 +70,7 @@ func testInput(t *testing.T, answers map[string]string) *mockInput {
 
 func testBackendDefault(t *testing.T) (*Remote, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -83,7 +83,7 @@ func testBackendDefault(t *testing.T) (*Remote, func()) {
 
 func testBackendNoDefault(t *testing.T) (*Remote, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -96,7 +96,7 @@ func testBackendNoDefault(t *testing.T) (*Remote, func()) {
 
 func testBackendNoOperations(t *testing.T) (*Remote, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("no-operations"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -732,7 +732,7 @@ func TestCloud_config(t *testing.T) {
 
 func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 	config := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -769,7 +769,7 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 
 func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 	config := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -813,7 +813,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 	workspaceName := "unavailable-terraform-version"
 
 	config := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -885,19 +885,6 @@ func TestCloud_setConfigurationFields(t *testing.T) {
 				}),
 			}),
 			expectedHostname:     "hashicorp.com",
-			expectedOrganziation: "hashicorp",
-		},
-		"with hostname not set, set to default hostname": {
-			obj: cty.ObjectVal(map[string]cty.Value{
-				"organization": cty.StringVal("hashicorp"),
-				"hostname":     cty.NullVal(cty.String),
-				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.StringVal("prod"),
-					"tags":    cty.NullVal(cty.Set(cty.String)),
-					"project": cty.NullVal(cty.String),
-				}),
-			}),
-			expectedHostname:     "app.terraform.io",
 			expectedOrganziation: "hashicorp",
 		},
 		"with workspace name set": {
@@ -1427,7 +1414,7 @@ func TestCloud_ServiceDiscoveryAliases(t *testing.T) {
 	b := New(testDisco(s))
 
 	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String), // Forces aliasing to test server
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	tfeHost  = svchost.Hostname(defaultHostname)
+	tfeHost  = svchost.Hostname("app.terraform.io")
 	credsSrc = auth.StaticCredentialsSource(map[svchost.Hostname]map[string]interface{}{
 		tfeHost: {"token": testCred},
 	})
@@ -89,7 +89,7 @@ func testBackendWithName(t *testing.T) (*Cloud, func()) {
 
 func testBackendAndMocksWithName(t *testing.T) (*Cloud, *MockClient, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -103,7 +103,7 @@ func testBackendAndMocksWithName(t *testing.T) (*Cloud, *MockClient, func()) {
 
 func testBackendWithTags(t *testing.T) (*Cloud, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -581,7 +581,7 @@ func testDisco(s *httptest.Server) *disco.Disco {
 	d := disco.NewWithCredentialsSource(credsSrc)
 	d.SetUserAgent(httpclient.OpenTfUserAgent(version.String()))
 
-	d.ForceHostServices(svchost.Hostname(defaultHostname), services)
+	d.ForceHostServices(svchost.Hostname("app.terraform.io"), services)
 	d.ForceHostServices(svchost.Hostname("localhost"), services)
 	d.ForceHostServices(svchost.Hostname("nontfe.local"), nil)
 	return d

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -122,7 +122,7 @@ func testBackendWithTags(t *testing.T) (*Cloud, func()) {
 
 func testBackendNoOperations(t *testing.T) (*Cloud, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("no-operations"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -137,7 +137,7 @@ func testBackendNoOperations(t *testing.T) (*Cloud, func()) {
 
 func testBackendWithHandlers(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (*Cloud, func()) {
 	obj := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.NullVal(cty.String),
+		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -51,9 +51,9 @@ func (c *LoginCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) > 1 {
+	if len(args) != 1 {
 		c.Ui.Error(
-			"The login command expects at most one argument: the host to log in to.")
+			"The login command expects exactly one argument: the host to log in to.")
 		cmdFlags.Usage()
 		return 1
 	}
@@ -70,10 +70,7 @@ func (c *LoginCommand) Run(args []string) int {
 		return 1
 	}
 
-	givenHostname := "app.terraform.io"
-	if len(args) != 0 {
-		givenHostname = args[0]
-	}
+	givenHostname := args[0]
 
 	hostname, err := svchost.ForComparison(givenHostname)
 	if err != nil {
@@ -263,7 +260,7 @@ func (c *LoginCommand) Run(args []string) int {
 			return 0
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			c.logMOTDError(err)
 			c.outputDefaultTFCLoginSuccess()
@@ -343,9 +340,6 @@ Usage: opentf [global options] login [hostname]
 
   Retrieves an authentication token for the given hostname, if it supports
   automatic login, and saves it in a credentials file in your home directory.
-
-  If no hostname is provided, the default hostname is app.terraform.io, to
-  log in to Terraform Cloud.
 
   If not overridden by credentials helper settings in the CLI configuration,
   the credentials will be written to the following local file:

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -105,6 +105,17 @@ func TestLogin(t *testing.T) {
 		}
 	}
 
+	t.Run("no hostname provided", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
+		status := c.Run([]string{})
+		if status == 0 {
+			t.Fatalf("successful exit; want error")
+		}
+
+		if got, want := ui.ErrorWriter.String(), "The login command expects exactly one argument"; !strings.Contains(got, want) {
+			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
+		}
+	}))
+
 	t.Run("app.terraform.io (no login support)", loginTestCase(func(t *testing.T, c *LoginCommand, ui *cli.MockUi) {
 		// Enter "yes" at the consent prompt, then paste a token with some
 		// accidental whitespace.
@@ -267,7 +278,7 @@ func TestLogin(t *testing.T) {
 		defer testInputMap(t, map[string]string{
 			"approve": "no",
 		})()
-		status := c.Run(nil)
+		status := c.Run([]string{"app.terraform.io"})
 		if status != 1 {
 			t.Fatalf("unexpected error code %d\nstderr:\n%s", status, ui.ErrorWriter.String())
 		}
@@ -282,7 +293,7 @@ func TestLogin(t *testing.T) {
 		defer testInputMap(t, map[string]string{
 			"approve": "y",
 		})()
-		status := c.Run(nil)
+		status := c.Run([]string{"app.terraform.io"})
 		if status != 1 {
 			t.Fatalf("unexpected error code %d\nstderr:\n%s", status, ui.ErrorWriter.String())
 		}

--- a/internal/command/logout.go
+++ b/internal/command/logout.go
@@ -30,19 +30,16 @@ func (c *LogoutCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	if len(args) > 1 {
+	if len(args) != 1 {
 		c.Ui.Error(
-			"The logout command expects at most one argument: the host to log out of.")
+			"The logout command expects exactly one argument: the host to log out of.")
 		cmdFlags.Usage()
 		return 1
 	}
 
 	var diags tfdiags.Diagnostics
 
-	givenHostname := "app.terraform.io"
-	if len(args) != 0 {
-		givenHostname = args[0]
-	}
+	givenHostname := args[0]
 
 	hostname, err := svchost.ForComparison(givenHostname)
 	if err != nil {
@@ -138,8 +135,6 @@ Usage: opentf [global options] logout [hostname]
 
   Note: the API token is only removed from local storage, not destroyed on the
   remote server, so it will remain valid until manually revoked.
-
-  If no hostname is provided, the default hostname is app.terraform.io.
       %s
 `
 	return strings.TrimSpace(helpText)

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -29,7 +29,7 @@ working directory.
 terraform {
   cloud {
     organization = "my-org"
-    hostname = "app.example.org" # Optional; defaults to app.terraform.io
+    hostname = "app.example.org"
 
     workspaces {
       project = "networking-development"

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -55,6 +55,8 @@ directly - it ignores the block and behaves according to its own workspace setti
 
 The `cloud` block supports the following configuration arguments:
 
+- `hostname` - (Required) The hostname of the cloud backend.
+
 - `organization` - (Required) The name of the organization containing the
   workspace(s) the current configuration should use.
 
@@ -76,8 +78,6 @@ The `cloud` block supports the following configuration arguments:
   - `project` - (Optional) The name of a cloud backend project. Workspaces that need created will
     will be created within this project. `opentf workspace list` will be filtered by workspaces
     in the supplied project.
-
-- `hostname` - (Optional) The hostname of the cloud backend.
 
 - `token` - (Optional) The token used to authenticate with the cloud backend.
   We recommend omitting the token from the configuration, and instead using

--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -174,8 +174,7 @@ data "terraform_remote_state" "foo" {
 
 The following configuration options are supported:
 
-- `hostname` - (Optional) The remote backend hostname to connect to. Defaults
-  to app.terraform.io.
+- `hostname` - (Required) The remote backend hostname to connect to.
 - `organization` - (Required) The name of the organization containing the
   targeted workspace(s).
 - `token` - (Optional) The token used to authenticate with the remote backend.


### PR DESCRIPTION
Legacy Terraform used a default value of "app.terraform.io" for:

- the `login` and `logout` commands, when the commands were called with no arguments;
- the `remote` backend when the `hostname` attribute has not been specified;
- the `cloud` backend when neither the `hostname` attribute nor the `TF_CLOUD_HOSTNAME` environment variable were set;

This could be confusing to an OpenTF user, and unfair to other vendors offering this kind of integration with the OpenTF CLI, so as of this PR, these values are explicitly required.

Note that the code contains some extra provisions for `app.terraform.io` to accommodate its quirks, and these were not removed to not change the current level of support, so that TFC customers can still use OpenTF.

Closes #269.