### PR TITLE
Use our fork of the equivalence testing binary

### DIFF
--- a/.github/scripts/equivalence-test.sh
+++ b/.github/scripts/equivalence-test.sh
@@ -17,7 +17,7 @@ Commands:
     download_equivalence_test_binary downloads the equivalence testing binary
     for a given version and places it at the target path.
 
-    ./equivalence-test.sh download_equivalence_test_binary 0.3.0 ./bin/opentf-equivalence-testing linux amd64
+    ./equivalence-test.sh download_equivalence_test_binary 0.4.0 ./bin/equivalence-testing linux amd64
 EOF
 }
 
@@ -35,18 +35,18 @@ function download_equivalence_test_binary {
 
   curl \
     -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/hashicorp/terraform-equivalence-testing/releases" > releases.json
+    "https://api.github.com/repos/opentffoundation/equivalence-testing/releases" > releases.json
 
-  ASSET="opentf-equivalence-testing_v${VERSION}_${OS}_${ARCH}.zip"
+  ASSET="equivalence-testing_v${VERSION}_${OS}_${ARCH}.zip"
   ASSET_ID=$(jq -r --arg VERSION "v$VERSION" --arg ASSET "$ASSET" '.[] | select(.name == $VERSION) | .assets[] | select(.name == $ASSET) | .id' releases.json)
 
   mkdir -p zip
   curl -L \
     -H "Accept: application/octet-stream" \
-    "https://api.github.com/repos/hashicorp/terraform-equivalence-testing/releases/assets/$ASSET_ID" > "zip/$ASSET"
+    "https://api.github.com/repos/opentffoundation/equivalence-testing/releases/assets/$ASSET_ID" > "zip/$ASSET"
 
   mkdir -p bin
-  unzip -p "zip/$ASSET" terraform-equivalence-testing > "$TARGET"
+  unzip -p "zip/$ASSET" equivalence-testing > "$TARGET"
   chmod u+x "$TARGET"
   rm -r zip
   rm releases.json

--- a/.github/workflows/compare-snapshots.yml
+++ b/.github/workflows/compare-snapshots.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Get the equivalence test binary
         run: |
           ./.github/scripts/equivalence-test.sh download_equivalence_test_binary \
-            0.3.0 \
-            ./bin/equivalence-tests \
+            0.4.0 \
+            ./bin/equivalence-testing \
             linux \
             amd64
 
@@ -36,23 +36,11 @@ jobs:
 
       - name: Run the equivalence tests
         run: |
-          export OTF_OVERRIDE_PLAN_TIMESTAMP_FOR_SNAPSHOTS="2023-08-24T12:33:30Z"
-          ./bin/equivalence-tests update \
+          ./bin/equivalence-testing update \
             --tests=testing/equivalence-tests/tests \
             --goldens=testing/equivalence-tests/outputs \
-            --binary=./bin/opentf
-
-      - name: Normalise execution time based changes
-        shell: bash
-        run: |
-          changed_execution_time=$(git diff --quiet -S "complete after 0s" -- testing/equivalence-tests/outputs || echo true)
-          if [[ "$changed_execution_time" == "true" ]]; then
-            echo "Found changes in the execution times in the result outputs. Defaulting the execution times to 0"
-            find testing/equivalence-tests/outputs -type f -name "apply.json" -exec sed -E -i 's/complete after [0-9]+s/complete after 0s/g' {} +
-            find testing/equivalence-tests/outputs -type f -name "apply.json" -exec sed -E -i 's/\"elapsed_seconds\"\: [0-9]+/\"elapsed_seconds\"\: 0/g' {} +
-          else
-            echo "Found no in the execution time in result outputs."
-          fi
+            --rewrites=testing/rewrites.jsonc \
+            --binary=./bin/opentf \
 
       - name: Ensure there is no diff
         shell: bash

--- a/internal/opentf/context_plan.go
+++ b/internal/opentf/context_plan.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -592,21 +591,6 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	}
 
 	timestamp := time.Now().UTC()
-
-	// This may not be pretty but it serves a single purpose, which is to ensure
-	// that we don't get false alerts on plan snapshots changing. This is never
-	// intended to be used in production, and is only for use in our CI system.
-	if tsOverride := os.Getenv("OTF_OVERRIDE_PLAN_TIMESTAMP_FOR_SNAPSHOTS"); tsOverride != "" {
-		var err error
-
-		if timestamp, err = time.Parse(time.RFC3339, tsOverride); err != nil {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Invalid timestamp override",
-				fmt.Sprintf("The OTF_OVERRIDE_PLAN_TIMESTAMP_FOR_SNAPSHOTS environment variable is set to an invalid timestamp: %s", err)),
-			)
-		}
-	}
 
 	// If we get here then we should definitely have a non-nil "graph", which
 	// we can now walk.

--- a/testing/equivalence-tests/outputs/basic_json_string_update/apply.json
+++ b/testing/equivalence-tests/outputs/basic_json_string_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.json: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.json: Modifying... [id=5a3fd9b3-e852-8956-8c0a-255d47eda645]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.json: Modifications complete after 0s [id=5a3fd9b3-e852-8956-8c0a-255d47eda645]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_json_string_update/plan.json
+++ b/testing/equivalence-tests/outputs/basic_json_string_update/plan.json
@@ -108,6 +108,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_list/apply.json
+++ b/testing/equivalence-tests/outputs/basic_list/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Creation complete after 0s [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_list/plan.json
+++ b/testing/equivalence-tests/outputs/basic_list/plan.json
@@ -94,6 +94,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_list_empty/apply.json
+++ b/testing/equivalence-tests/outputs/basic_list_empty/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Modifying... [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Modifications complete after 0s [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_list_empty/plan.json
+++ b/testing/equivalence-tests/outputs/basic_list_empty/plan.json
@@ -119,6 +119,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_list_null/apply.json
+++ b/testing/equivalence-tests/outputs/basic_list_null/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Modifying... [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Modifications complete after 0s [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_list_null/plan.json
+++ b/testing/equivalence-tests/outputs/basic_list_null/plan.json
@@ -112,6 +112,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_list_update/apply.json
+++ b/testing/equivalence-tests/outputs/basic_list_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Modifying... [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Modifications complete after 0s [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_list_update/plan.json
+++ b/testing/equivalence-tests/outputs/basic_list_update/plan.json
@@ -139,6 +139,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_map/apply.json
+++ b/testing/equivalence-tests/outputs/basic_map/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Creation complete after 0s [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_map/plan.json
+++ b/testing/equivalence-tests/outputs/basic_map/plan.json
@@ -86,6 +86,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_map_empty/apply.json
+++ b/testing/equivalence-tests/outputs/basic_map_empty/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Modifying... [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Modifications complete after 0s [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_map_empty/plan.json
+++ b/testing/equivalence-tests/outputs/basic_map_empty/plan.json
@@ -111,6 +111,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_map_null/apply.json
+++ b/testing/equivalence-tests/outputs/basic_map_null/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Modifying... [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Modifications complete after 0s [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_map_null/plan.json
+++ b/testing/equivalence-tests/outputs/basic_map_null/plan.json
@@ -104,6 +104,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_map_update/apply.json
+++ b/testing/equivalence-tests/outputs/basic_map_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Modifying... [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Modifications complete after 0s [id=50E1A46E-E64A-4C1F-881C-BA85A5440964]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_map_update/plan.json
+++ b/testing/equivalence-tests/outputs/basic_map_update/plan.json
@@ -123,6 +123,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_multiline_string_update/apply.json
+++ b/testing/equivalence-tests/outputs/basic_multiline_string_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.multiline: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.multiline: Modifying... [id=69fe5233-e77a-804f-0dac-115c949540bc]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.multiline: Modifications complete after 0s [id=69fe5233-e77a-804f-0dac-115c949540bc]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_multiline_string_update/plan.json
+++ b/testing/equivalence-tests/outputs/basic_multiline_string_update/plan.json
@@ -108,6 +108,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_set/apply.json
+++ b/testing/equivalence-tests/outputs/basic_set/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Creation complete after 0s [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_set/plan.json
+++ b/testing/equivalence-tests/outputs/basic_set/plan.json
@@ -94,6 +94,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_set_empty/apply.json
+++ b/testing/equivalence-tests/outputs/basic_set_empty/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Modifying... [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Modifications complete after 0s [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_set_empty/plan.json
+++ b/testing/equivalence-tests/outputs/basic_set_empty/plan.json
@@ -119,6 +119,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_set_null/apply.json
+++ b/testing/equivalence-tests/outputs/basic_set_null/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Modifying... [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Modifications complete after 0s [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_set_null/plan.json
+++ b/testing/equivalence-tests/outputs/basic_set_null/plan.json
@@ -112,6 +112,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/basic_set_update/apply.json
+++ b/testing/equivalence-tests/outputs/basic_set_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Modifying... [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Modifications complete after 0s [id=046952C9-B832-4106-82C0-C217F7C73E18]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/basic_set_update/plan.json
+++ b/testing/equivalence-tests/outputs/basic_set_update/plan.json
@@ -139,6 +139,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/data_read/plan.json
+++ b/testing/equivalence-tests/outputs/data_read/plan.json
@@ -324,6 +324,5 @@
       "provider_name": "registry.terraform.io/hashicorp/random",
       "type": "random_integer"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/drift_refresh_only/apply.json
+++ b/testing/equivalence-tests/outputs/drift_refresh_only/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -15,7 +14,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/drift_refresh_only/plan.json
+++ b/testing/equivalence-tests/outputs/drift_refresh_only/plan.json
@@ -88,6 +88,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/drift_relevant_attributes/apply.json
+++ b/testing/equivalence-tests/outputs/drift_relevant_attributes/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.base: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.dependent: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.base: Modifying... [id=f6f74ca6-e8ef-e51f-522c-433b9ed5038f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -58,7 +55,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.base: Modifications complete after 0s [id=f6f74ca6-e8ef-e51f-522c-433b9ed5038f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -79,7 +75,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.dependent: Modifying... [id=1b17b502-96c9-fcc3-3b09-2af1c3de6ad8]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.dependent: Modifications complete after 0s [id=1b17b502-96c9-fcc3-3b09-2af1c3de6ad8]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -120,7 +114,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 2 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 2,
@@ -133,7 +126,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/drift_relevant_attributes/plan.json
+++ b/testing/equivalence-tests/outputs/drift_relevant_attributes/plan.json
@@ -236,6 +236,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/drift_simple/apply.json
+++ b/testing/equivalence-tests/outputs/drift_simple/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.drift: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.drift: Modifying... [id=f3c6ddc5-37d5-0170-64ff-518ad421385a]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.drift: Modifications complete after 0s [id=f3c6ddc5-37d5-0170-64ff-518ad421385a]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/drift_simple/plan.json
+++ b/testing/equivalence-tests/outputs/drift_simple/plan.json
@@ -141,6 +141,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/fully_populated_complex/apply.json
+++ b/testing/equivalence-tests/outputs/fully_populated_complex/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Creation complete after 0s [id=64564E36-BFCB-458B-9405-EBBF6A3CAC7A]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/fully_populated_complex/plan.json
+++ b/testing/equivalence-tests/outputs/fully_populated_complex/plan.json
@@ -1541,6 +1541,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_complex_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/fully_populated_complex_destroy/apply.json
+++ b/testing/equivalence-tests/outputs/fully_populated_complex_destroy/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Refreshing state... [id=64564E36-BFCB-458B-9405-EBBF6A3CAC7A]",
-    "@module": "opentf.ui",
     "hook": {
       "id_key": "id",
       "id_value": "64564E36-BFCB-458B-9405-EBBF6A3CAC7A",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Refresh complete [id=64564E36-BFCB-458B-9405-EBBF6A3CAC7A]",
-    "@module": "opentf.ui",
     "hook": {
       "id_key": "id",
       "id_value": "64564E36-BFCB-458B-9405-EBBF6A3CAC7A",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Plan to delete",
-    "@module": "opentf.ui",
     "change": {
       "action": "delete",
       "resource": {
@@ -58,7 +55,6 @@
   {
     "@level": "info",
     "@message": "Plan: 0 to add, 0 to change, 1 to destroy.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -71,7 +67,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Destroying... [id=64564E36-BFCB-458B-9405-EBBF6A3CAC7A]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -91,7 +86,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -110,7 +104,6 @@
   {
     "@level": "info",
     "@message": "Destroy complete! Resources: 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,

--- a/testing/equivalence-tests/outputs/fully_populated_complex_destroy/plan.json
+++ b/testing/equivalence-tests/outputs/fully_populated_complex_destroy/plan.json
@@ -1542,6 +1542,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_complex_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/fully_populated_complex_update/apply.json
+++ b/testing/equivalence-tests/outputs/fully_populated_complex_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Modifying... [id=64564E36-BFCB-458B-9405-EBBF6A3CAC7A]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_complex_resource.complex: Modifications complete after 0s [id=64564E36-BFCB-458B-9405-EBBF6A3CAC7A]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/fully_populated_complex_update/plan.json
+++ b/testing/equivalence-tests/outputs/fully_populated_complex_update/plan.json
@@ -2831,6 +2831,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_complex_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/local_provider_basic/apply.json
+++ b/testing/equivalence-tests/outputs/local_provider_basic/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Creation complete after 0s [id=2248ee2fa0aaaad99178531f924bf00b4b0a8f4e]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/local_provider_basic/plan.json
+++ b/testing/equivalence-tests/outputs/local_provider_basic/plan.json
@@ -86,6 +86,5 @@
       "provider_name": "registry.terraform.io/hashicorp/local",
       "type": "local_file"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/local_provider_delete/apply.json
+++ b/testing/equivalence-tests/outputs/local_provider_delete/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Plan to delete",
-    "@module": "opentf.ui",
     "change": {
       "action": "delete",
       "reason": "delete_because_no_resource_config",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Destroying... [id=2248ee2fa0aaaad99178531f924bf00b4b0a8f4e]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -73,7 +69,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/local_provider_delete/plan.json
+++ b/testing/equivalence-tests/outputs/local_provider_delete/plan.json
@@ -74,6 +74,5 @@
       "provider_name": "registry.terraform.io/hashicorp/local",
       "type": "local_file"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/local_provider_update/apply.json
+++ b/testing/equivalence-tests/outputs/local_provider_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Plan to replace",
-    "@module": "opentf.ui",
     "change": {
       "action": "replace",
       "reason": "cannot_update",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Destroying... [id=2248ee2fa0aaaad99178531f924bf00b4b0a8f4e]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -78,7 +74,6 @@
   {
     "@level": "info",
     "@message": "local_file.local_file: Creation complete after 0s [id=648a5452054fca119f95b07f9ea992cc6d9681df]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -112,7 +106,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/local_provider_update/plan.json
+++ b/testing/equivalence-tests/outputs/local_provider_update/plan.json
@@ -134,6 +134,5 @@
       "provider_name": "registry.terraform.io/hashicorp/local",
       "type": "local_file"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/moved_simple/apply.json
+++ b/testing/equivalence-tests/outputs/moved_simple/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -15,7 +14,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/moved_simple/plan.json
+++ b/testing/equivalence-tests/outputs/moved_simple/plan.json
@@ -109,6 +109,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/moved_with_drift/apply.json
+++ b/testing/equivalence-tests/outputs/moved_with_drift/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.base_after: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "previous_resource": {
@@ -29,7 +28,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.dependent: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -47,7 +45,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.base_after: Modifying... [id=e450ef2f-b80f-0cce-8bdb-14d88f48649c]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -67,7 +64,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.base_after: Modifications complete after 0s [id=e450ef2f-b80f-0cce-8bdb-14d88f48649c]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -88,7 +84,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.dependent: Modifying... [id=2ecc718c-8d04-5774-5c36-7d69bf77d34e]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -108,7 +103,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.dependent: Modifications complete after 0s [id=2ecc718c-8d04-5774-5c36-7d69bf77d34e]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -129,7 +123,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 2 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 2,
@@ -142,7 +135,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/moved_with_drift/plan.json
+++ b/testing/equivalence-tests/outputs/moved_with_drift/plan.json
@@ -236,6 +236,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/moved_with_refresh_only/apply.json
+++ b/testing/equivalence-tests/outputs/moved_with_refresh_only/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -15,7 +14,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/moved_with_refresh_only/plan.json
+++ b/testing/equivalence-tests/outputs/moved_with_refresh_only/plan.json
@@ -89,6 +89,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/moved_with_update/apply.json
+++ b/testing/equivalence-tests/outputs/moved_with_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.moved: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "previous_resource": {
@@ -29,7 +28,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.moved: Modifying... [id=7da63aeb-f908-a112-9886-f29a0b0bd4ad]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -49,7 +47,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_simple_resource.moved: Modifications complete after 0s [id=7da63aeb-f908-a112-9886-f29a0b0bd4ad]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -70,7 +67,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -83,7 +79,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/moved_with_update/plan.json
+++ b/testing/equivalence-tests/outputs/moved_with_update/plan.json
@@ -109,6 +109,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_simple_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/multiple_block_types/apply.json
+++ b/testing/equivalence-tests/outputs/multiple_block_types/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_multiple_blocks.multiple_blocks: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_multiple_blocks.multiple_blocks: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_multiple_blocks.multiple_blocks: Creation complete after 0s [id=DA051126-BAD6-4EB2-92E5-F0250DAF0B92]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/multiple_block_types/plan.json
+++ b/testing/equivalence-tests/outputs/multiple_block_types/plan.json
@@ -152,6 +152,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_multiple_blocks"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/multiple_block_types_update/apply.json
+++ b/testing/equivalence-tests/outputs/multiple_block_types_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_multiple_blocks.multiple_blocks: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_multiple_blocks.multiple_blocks: Modifying... [id=DA051126-BAD6-4EB2-92E5-F0250DAF0B92]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_multiple_blocks.multiple_blocks: Modifications complete after 0s [id=DA051126-BAD6-4EB2-92E5-F0250DAF0B92]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/multiple_block_types_update/plan.json
+++ b/testing/equivalence-tests/outputs/multiple_block_types_update/plan.json
@@ -233,6 +233,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_multiple_blocks"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_list/apply.json
+++ b/testing/equivalence-tests/outputs/nested_list/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_list.nested_list: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_list.nested_list: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_list.nested_list: Creation complete after 0s [id=DA051126-BAD6-4EB2-92E5-F0250DAF0B92]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_list/plan.json
+++ b/testing/equivalence-tests/outputs/nested_list/plan.json
@@ -119,6 +119,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_list_update/apply.json
+++ b/testing/equivalence-tests/outputs/nested_list_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_list.nested_list: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_list.nested_list: Modifying... [id=DA051126-BAD6-4EB2-92E5-F0250DAF0B92]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_list.nested_list: Modifications complete after 0s [id=DA051126-BAD6-4EB2-92E5-F0250DAF0B92]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_list_update/plan.json
+++ b/testing/equivalence-tests/outputs/nested_list_update/plan.json
@@ -189,6 +189,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_map/apply.json
+++ b/testing/equivalence-tests/outputs/nested_map/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_map.nested_map: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_map.nested_map: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_map.nested_map: Creation complete after 0s [id=502B0348-B796-4F6A-8694-A5A397237B85]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_map/plan.json
+++ b/testing/equivalence-tests/outputs/nested_map/plan.json
@@ -107,6 +107,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_map_update/apply.json
+++ b/testing/equivalence-tests/outputs/nested_map_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_map.nested_map: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_map.nested_map: Modifying... [id=502B0348-B796-4F6A-8694-A5A397237B85]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_map.nested_map: Modifications complete after 0s [id=502B0348-B796-4F6A-8694-A5A397237B85]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_map_update/plan.json
+++ b/testing/equivalence-tests/outputs/nested_map_update/plan.json
@@ -160,6 +160,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_objects/apply.json
+++ b/testing/equivalence-tests/outputs/nested_objects/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_object.nested_object: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_object.nested_object: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_object.nested_object: Creation complete after 0s [id=B2491EF0-9361-40FD-B25A-0332A1A5E052]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_objects/plan.json
+++ b/testing/equivalence-tests/outputs/nested_objects/plan.json
@@ -107,6 +107,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_objects_update/apply.json
+++ b/testing/equivalence-tests/outputs/nested_objects_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_object.nested_object: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_object.nested_object: Modifying... [id=B2491EF0-9361-40FD-B25A-0332A1A5E052]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_object.nested_object: Modifications complete after 0s [id=B2491EF0-9361-40FD-B25A-0332A1A5E052]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_objects_update/plan.json
+++ b/testing/equivalence-tests/outputs/nested_objects_update/plan.json
@@ -160,6 +160,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_set/apply.json
+++ b/testing/equivalence-tests/outputs/nested_set/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_set.nested_set: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_set.nested_set: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_set.nested_set: Creation complete after 0s [id=510598F6-83FE-4090-8986-793293E90480]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_set/plan.json
+++ b/testing/equivalence-tests/outputs/nested_set/plan.json
@@ -119,6 +119,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/nested_set_update/apply.json
+++ b/testing/equivalence-tests/outputs/nested_set_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_set.nested_set: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_set.nested_set: Modifying... [id=510598F6-83FE-4090-8986-793293E90480]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_nested_set.nested_set: Modifications complete after 0s [id=510598F6-83FE-4090-8986-793293E90480]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/nested_set_update/plan.json
+++ b/testing/equivalence-tests/outputs/nested_set_update/plan.json
@@ -189,6 +189,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_nested_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/null_provider_delete/apply.json
+++ b/testing/equivalence-tests/outputs/null_provider_delete/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "null_resource.null_resource: Plan to delete",
-    "@module": "opentf.ui",
     "change": {
       "action": "delete",
       "reason": "delete_because_no_resource_config",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "null_resource.null_resource: Destroying... [id=7115293105928418144]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "null_resource.null_resource: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -73,7 +69,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/null_provider_delete/plan.json
+++ b/testing/equivalence-tests/outputs/null_provider_delete/plan.json
@@ -58,6 +58,5 @@
       "provider_name": "registry.terraform.io/hashicorp/null",
       "type": "null_resource"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/replace_within_list/apply.json
+++ b/testing/equivalence-tests/outputs/replace_within_list/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Plan to replace",
-    "@module": "opentf.ui",
     "change": {
       "action": "replace",
       "reason": "cannot_update",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Destroying... [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -78,7 +74,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_list.list: Creation complete after 0s [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -112,7 +106,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/replace_within_list/plan.json
+++ b/testing/equivalence-tests/outputs/replace_within_list/plan.json
@@ -178,6 +178,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_list"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/replace_within_map/apply.json
+++ b/testing/equivalence-tests/outputs/replace_within_map/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Plan to replace",
-    "@module": "opentf.ui",
     "change": {
       "action": "replace",
       "reason": "cannot_update",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Destroying... [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -78,7 +74,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_map.map: Creation complete after 0s [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -112,7 +106,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/replace_within_map/plan.json
+++ b/testing/equivalence-tests/outputs/replace_within_map/plan.json
@@ -178,6 +178,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_map"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/replace_within_object/apply.json
+++ b/testing/equivalence-tests/outputs/replace_within_object/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Plan to replace",
-    "@module": "opentf.ui",
     "change": {
       "action": "replace",
       "reason": "cannot_update",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Destroying... [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -78,7 +74,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Creation complete after 0s [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -112,7 +106,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/replace_within_object/plan.json
+++ b/testing/equivalence-tests/outputs/replace_within_object/plan.json
@@ -121,6 +121,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/replace_within_set/apply.json
+++ b/testing/equivalence-tests/outputs/replace_within_set/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Plan to replace",
-    "@module": "opentf.ui",
     "change": {
       "action": "replace",
       "reason": "cannot_update",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Destroying... [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -78,7 +74,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_set.set: Creation complete after 0s [id=F40F2AB4-100C-4AE8-BFD0-BF332A158415]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -112,7 +106,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/replace_within_set/plan.json
+++ b/testing/equivalence-tests/outputs/replace_within_set/plan.json
@@ -176,6 +176,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_set"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/simple_object/apply.json
+++ b/testing/equivalence-tests/outputs/simple_object/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Plan to create",
-    "@module": "opentf.ui",
     "change": {
       "action": "create",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -38,7 +36,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Creation complete after 0s [id=AF9833AE-3434-4D0B-8B69-F4B992565D9F]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -59,7 +56,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -72,7 +68,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/simple_object/plan.json
+++ b/testing/equivalence-tests/outputs/simple_object/plan.json
@@ -86,6 +86,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/simple_object_empty/apply.json
+++ b/testing/equivalence-tests/outputs/simple_object_empty/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Modifying... [id=00e14fba-4d56-6cc5-b685-633555376e3f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Modifications complete after 0s [id=00e14fba-4d56-6cc5-b685-633555376e3f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/simple_object_empty/plan.json
+++ b/testing/equivalence-tests/outputs/simple_object_empty/plan.json
@@ -116,6 +116,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/simple_object_null/apply.json
+++ b/testing/equivalence-tests/outputs/simple_object_null/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Modifying... [id=00e14fba-4d56-6cc5-b685-633555376e3f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Modifications complete after 0s [id=00e14fba-4d56-6cc5-b685-633555376e3f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/simple_object_null/plan.json
+++ b/testing/equivalence-tests/outputs/simple_object_null/plan.json
@@ -99,6 +99,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/simple_object_replace/apply.json
+++ b/testing/equivalence-tests/outputs/simple_object_replace/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Plan to replace",
-    "@module": "opentf.ui",
     "change": {
       "action": "replace",
       "reason": "cannot_update",
@@ -21,7 +20,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Destroying... [id=a0ed13ec-116b-14c4-7437-418e217d3659]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "id_key": "id",
@@ -41,7 +39,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Destruction complete after 0s",
-    "@module": "opentf.ui",
     "hook": {
       "action": "delete",
       "elapsed_seconds": 0,
@@ -60,7 +57,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Creating...",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "resource": {
@@ -78,7 +74,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Creation complete after 0s [id=63A9E8E8-71BC-4DAE-A66C-48CE393CCBD3]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "create",
       "elapsed_seconds": 0,
@@ -99,7 +94,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 1,
       "change": 0,
@@ -112,7 +106,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/simple_object_replace/plan.json
+++ b/testing/equivalence-tests/outputs/simple_object_replace/plan.json
@@ -130,6 +130,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/simple_object_update/apply.json
+++ b/testing/equivalence-tests/outputs/simple_object_update/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Plan to update",
-    "@module": "opentf.ui",
     "change": {
       "action": "update",
       "resource": {
@@ -20,7 +19,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Modifying... [id=00e14fba-4d56-6cc5-b685-633555376e3f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "id_key": "id",
@@ -40,7 +38,6 @@
   {
     "@level": "info",
     "@message": "tfcoremock_object.object: Modifications complete after 0s [id=00e14fba-4d56-6cc5-b685-633555376e3f]",
-    "@module": "opentf.ui",
     "hook": {
       "action": "update",
       "elapsed_seconds": 0,
@@ -61,7 +58,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 1 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 1,
@@ -74,7 +70,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 0",
-    "@module": "opentf.ui",
     "outputs": {},
     "type": "outputs"
   }

--- a/testing/equivalence-tests/outputs/simple_object_update/plan.json
+++ b/testing/equivalence-tests/outputs/simple_object_update/plan.json
@@ -120,6 +120,5 @@
       "provider_name": "registry.terraform.io/hashicorp/tfcoremock",
       "type": "tfcoremock_object"
     }
-  ],
-  "timestamp": "2023-08-24T12:33:30Z"
+  ]
 }

--- a/testing/equivalence-tests/outputs/variables_and_outputs/apply.json
+++ b/testing/equivalence-tests/outputs/variables_and_outputs/apply.json
@@ -2,7 +2,6 @@
   {
     "@level": "info",
     "@message": "Apply complete! Resources: 0 added, 0 changed, 0 destroyed.",
-    "@module": "opentf.ui",
     "changes": {
       "add": 0,
       "change": 0,
@@ -15,7 +14,6 @@
   {
     "@level": "info",
     "@message": "Outputs: 5",
-    "@module": "opentf.ui",
     "outputs": {
       "list_empty_default": {
         "sensitive": false,

--- a/testing/equivalence-tests/outputs/variables_and_outputs/plan.json
+++ b/testing/equivalence-tests/outputs/variables_and_outputs/plan.json
@@ -360,7 +360,6 @@
       "root_module": {}
     }
   },
-  "timestamp": "2023-08-24T12:33:30Z",
   "variables": {
     "list_empty_default": {
       "value": []

--- a/testing/rewrites.jsonc
+++ b/testing/rewrites.jsonc
@@ -1,0 +1,7 @@
+{
+    "apply.json": {
+      "complete after [0-9]+s": "complete after 0s",
+      "\"elapsed_seconds\": [0-9]+": "\"elapsed_seconds\": 0"
+    }
+  }
+  


### PR DESCRIPTION
In this PR, we replace the [original Hashi's equivalence testing binary](https://github.com/hashicorp/terraform-equivalence-testing) with our fork, which introduces a few nice things that allow us to use it as part of the CI test suite with confidence, even comparing between OpenTF and the legacy Terraform.

Few notable changes:
- the `@module` field in JSON logs is now ignored, because legacy Terraform and OpenTF use different values here;
- the plan `timestamp` fields are ignored by default, which allow us to remove the test timestamp overrides;
- global rewrites are introduced for apply logs, allowing us to elegantly de-flake tests which depend on duration;

Note that the snapshots are updated by removing `@module` and `timestamp` fields for future comparisons. This is expected.

Closes #163
