### PR TITLE
[RFC Implementation] Bypass gpg validation of packages if the registry does not provide any keys

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -816,7 +816,11 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				keyID = c.Colorize().Color(fmt.Sprintf(", key ID [reset][bold]%s[reset]", keyID))
 			}
 
-			c.Ui.Info(fmt.Sprintf("- Installed %s v%s (%s%s)", provider.ForDisplay(), version, authResult, keyID))
+			if authResult != nil && authResult.SigningSkipped() {
+				c.Ui.Warn(fmt.Sprintf("- Installed %s v%s. Signature validation was skipped due to the registry not containing GPG keys for this provider", provider.ForDisplay(), version))
+			} else {
+				c.Ui.Info(fmt.Sprintf("- Installed %s v%s (%s%s)", provider.ForDisplay(), version, authResult, keyID))
+			}
 		},
 		ProvidersLockUpdated: func(provider addrs.Provider, version getproviders.Version, localHashes []getproviders.Hash, signedHashes []getproviders.Hash, priorHashes []getproviders.Hash) {
 			// We're going to use this opportunity to track if we have any

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -357,7 +357,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	ret.Authentication = PackageAuthenticationAll(
 		NewMatchingChecksumAuthentication(document, body.Filename, checksum),
 		NewArchiveChecksumAuthentication(ret.TargetPlatform, checksum),
-		NewSignatureAuthentication(document, signature, keys),
+		NewSignatureAuthentication(document, signature, keys, &provider),
 	)
 
 	return ret, nil

--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+
 	"github.com/apparentlymart/go-versions/versions"
 	"github.com/google/go-cmp/cmp"
 	svchost "github.com/hashicorp/terraform-svchost"
@@ -150,6 +152,7 @@ func TestSourcePackageMeta(t *testing.T) {
 						[]SigningKey{
 							{ASCIIArmor: TestingPublicKey},
 						},
+						&tfaddr.Provider{Hostname: "example.com", Namespace: "awesomesauce", Type: "happycloud"},
 					),
 				),
 			},

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -675,9 +675,13 @@ NeedProvider:
 		}
 
 		var signedHashes []getproviders.Hash
-		if authResult.Signed() {
+		// For now, we will temporarily trust the hashes returned by the
+		// installation process that are "SigningSkipped" or "Signed".
+		// This is only intended to be temporary, see https://github.com/opentffoundation/opentf/issues/266 for more information
+		if authResult.Signed() || authResult.SigningSkipped() {
 			// We'll trust new hashes from upstream only if they were verified
-			// as signed by a suitable key. Otherwise, we'd record only
+			// as signed by a suitable key or if the signing validation was skipped.
+			// Otherwise, we'd record only
 			// a new hash we just calculated ourselves from the bytes on disk,
 			// and so the hashes would cover only the current platform.
 			signedHashes = append(signedHashes, meta.AcceptableHashes()...)


### PR DESCRIPTION
RFC: #266 

Summary:
- Introduced a dedicated function `shouldEnforceGPGValidation()` to determine if GPG validation should be enforced.
- GPG validation is now prioritized if signing keys are provided, ensuring a secure-by-default approach.
- Addressed a minor typo in comments for clarity.

Details:
- The new method simplifies the logic in `AuthenticatePackage()` and can be reused if needed in other parts of the code.
- By checking for the presence of signing keys first, we ensure that validation takes precedence over environment variable configurations.
- A TODO has been added to discuss how unvalidated packages should be represented in the result, suggesting the potential use of a hardcoded "UNKNOWN" value.

Note: Further consideration is required on how best to represent unvalidated packages in the authentication result.

Fixes #266 

## Target Release

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

- IMPORTANT: When downloading providers through the opentf registry, skip validation for packages that do not have a GPG key attached. This can be overridden by setting `OPENTF_ENFORCE_GPG_VALIDATION`. By setting this environment variable to `"true"`, opentf will attempt to validate all package downloads.
-  
