### PR TITLE
Fix Slack workspace link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - Manifesto: https://opentf.org
 - About the OpenTF fork: https://opentf.org/fork
-- [Join our Slack community!](https://join.slack.com/t/slack-9uv6202/shared_invite/zt-22ifsm1t2-AF6cL0cOdzivP8E~4deDJA)
+- [Join our Slack community!](https://join.slack.com/t/opentfcommunity/shared_invite/zt-22ifsm1t2-AF6cL0cOdzivP8E~4deDJA)
 
 <img alt="OpenTF" src="https://raw.githubusercontent.com/opentffoundation/brand-artifacts/main/full/transparent/SVG/on-light.svg" width="600px">
 


### PR DESCRIPTION
Fixes #275 