### PR TITLE
internal/backend: deprecate io/ioutil

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -10,7 +10,6 @@ package backend
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -432,7 +431,7 @@ func ReadPathOrContents(poc string) (string, error) {
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return string(contents), err
 		}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -5,7 +5,6 @@ package backend
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"strings"
@@ -121,7 +120,7 @@ func testTempFile(t *testing.T, baseDir ...string) (*os.File, func()) {
 	if len(baseDir) == 1 {
 		base = baseDir[0]
 	}
-	f, err := ioutil.TempFile(base, "tf")
+	f, err := os.CreateTemp(base, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -196,7 +195,7 @@ func (b *Local) Workspaces() ([]string, error) {
 	// the listing always start with "default"
 	envs := []string{backend.DefaultStateName}
 
-	entries, err := ioutil.ReadDir(b.stateWorkspaceDir())
+	entries, err := os.ReadDir(b.stateWorkspaceDir())
 	// no error if there's no envs configured
 	if os.IsNotExist(err) {
 		return envs, nil

--- a/internal/backend/remote-state/consul/backend_test.go
+++ b/internal/backend/remote-state/consul/backend_test.go
@@ -6,7 +6,7 @@ package consul
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -32,8 +32,8 @@ func newConsulTestServer(t *testing.T) *testutil.TestServer {
 		}
 
 		if !testing.Verbose() {
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		}
 	})
 

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -9,7 +9,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -201,7 +201,7 @@ func (c *remoteClient) getObject(cosFile string) (exists bool, data []byte, chec
 	}
 
 	exists = true
-	data, err = ioutil.ReadAll(rsp.Body)
+	data, err = io.ReadAll(rsp.Body)
 	log.Printf("[DEBUG] getObject %s: data length: %d", cosFile, len(data))
 	if err != nil {
 		err = fmt.Errorf("failed to open file at %v: %v", cosFile, err)

--- a/internal/backend/remote-state/cos/transport.go
+++ b/internal/backend/remote-state/cos/transport.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -48,7 +48,7 @@ func (me *LogRoundTripper) RoundTrip(request *http.Request) (response *http.Resp
 
 	request.Header.Set("X-TC-RequestClient", ReqClient)
 	inBytes = []byte(fmt.Sprintf("%s, request: ", request.Header[headName]))
-	requestBody, errRet := ioutil.ReadAll(bodyReader)
+	requestBody, errRet := io.ReadAll(bodyReader)
 	if errRet != nil {
 		return
 	}
@@ -67,11 +67,11 @@ func (me *LogRoundTripper) RoundTrip(request *http.Request) (response *http.Resp
 	if errRet != nil {
 		return
 	}
-	outBytes, errRet = ioutil.ReadAll(response.Body)
+	outBytes, errRet = io.ReadAll(response.Body)
 	if errRet != nil {
 		return
 	}
-	response.Body = ioutil.NopCloser(bytes.NewBuffer(outBytes))
+	response.Body = io.NopCloser(bytes.NewBuffer(outBytes))
 	return
 }
 

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -6,7 +6,7 @@ package gcs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 
 	"cloud.google.com/go/storage"
@@ -40,7 +40,7 @@ func (c *remoteClient) Get() (payload *remote.Payload, err error) {
 	}
 	defer stateFileReader.Close()
 
-	stateFileContents, err := ioutil.ReadAll(stateFileReader)
+	stateFileContents, err := io.ReadAll(stateFileReader)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read state file from %v: %v", c.stateFileURL(), err)
 	}
@@ -150,7 +150,7 @@ func (c *remoteClient) lockInfo() (*statemgr.LockInfo, error) {
 	}
 	defer r.Close()
 
-	rawData, err := ioutil.ReadAll(r)
+	rawData, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -101,7 +100,7 @@ func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 		return "", fmt.Errorf("HTTP remote state endpoint invalid auth")
 	case http.StatusConflict, http.StatusLocked:
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", &statemgr.LockError{
 				Info: info,

--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -566,7 +565,7 @@ func getConfigFromProfile(d *schema.ResourceData, ProfileKey string) (interface{
 		providerConfig = make(map[string]interface{})
 		_, err = os.Stat(profilePath)
 		if !os.IsNotExist(err) {
-			data, err := ioutil.ReadFile(profilePath)
+			data, err := os.ReadFile(profilePath)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -243,7 +242,7 @@ in order to capture the filesystem context the remote workspace expects:
 		// We did a check earlier to make sure we either have a config dir,
 		// or the plan is run with -destroy. So this else clause will only
 		// be executed when we are destroying and doesn't need the config.
-		configDir, err = ioutil.TempDir("", "tf")
+		configDir, err = os.MkdirTemp("", "tf")
 		if err != nil {
 			return nil, generalError("Failed to create temporary directory", err)
 		}


### PR DESCRIPTION
This removes all usage of the deprecated `io/ioutil` package throughout `internal/backend` and its subpackages.

There is nothing user-facing here, I don't think a CHANGELOG entry is warranted.

https://github.com/opentffoundation/opentf/issues/313