### PR TITLE
internal/cloud: deprecate io/ioutil

### DIFF
--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -173,7 +172,7 @@ in order to capture the filesystem context the remote workspace expects:
 		// We did a check earlier to make sure we either have a config dir,
 		// or the plan is run with -destroy. So this else clause will only
 		// be executed when we are destroying and doesn't need the config.
-		configDir, err = ioutil.TempDir("", "tf")
+		configDir, err = os.MkdirTemp("", "tf")
 		if err != nil {
 			return nil, generalError("Failed to create temporary directory", err)
 		}

--- a/internal/cloud/e2e/main_test.go
+++ b/internal/cloud/e2e/main_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -183,7 +182,7 @@ func setTfeClient() {
 
 func setupBinary() func() {
 	log.Println("Setting up terraform binary")
-	tmpTerraformBinaryDir, err := ioutil.TempDir("", "terraform-test")
+	tmpTerraformBinaryDir, err := os.MkdirTemp("", "terraform-test")
 	if err != nil {
 		fmt.Printf("Could not create temp directory: %v\n", err)
 		os.Exit(1)

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -6,7 +6,7 @@ package cloud
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -100,7 +100,7 @@ func TestState(t *testing.T) {
 
 	state := testCloudState(t)
 
-	jsonState, err := ioutil.ReadFile("../command/testdata/show-json-state/sensitive-variables/output.json")
+	jsonState, err := os.ReadFile("../command/testdata/show-json-state/sensitive-variables/output.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cloud/tfe_client_mock.go
+++ b/internal/cloud/tfe_client_mock.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -145,7 +144,7 @@ func (m *MockApplies) Logs(ctx context.Context, applyID string) (io.Reader, erro
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +334,7 @@ func (m *MockCostEstimates) Logs(ctx context.Context, costEstimateID string) (io
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +600,7 @@ func (m *MockPlans) Logs(ctx context.Context, planID string) (io.Reader, error) 
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -875,7 +874,7 @@ func (m *MockPolicyChecks) Read(ctx context.Context, policyCheckID string) (*tfe
 		return nil, fmt.Errorf("logfile does not exist")
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -924,7 +923,7 @@ func (m *MockPolicyChecks) Logs(ctx context.Context, policyCheckID string) (io.R
 		return bytes.NewBufferString("logfile does not exist"), nil
 	}
 
-	logs, err := ioutil.ReadFile(logfile)
+	logs, err := os.ReadFile(logfile)
 	if err != nil {
 		return nil, err
 	}
@@ -1217,7 +1216,7 @@ func (m *MockRuns) ReadWithOptions(ctx context.Context, runID string, options *t
 		r.Plan.Status = tfe.PlanRunning
 	}
 
-	logs, _ := ioutil.ReadFile(m.client.Plans.logs[r.Plan.LogReadURL])
+	logs, _ := os.ReadFile(m.client.Plans.logs[r.Plan.LogReadURL])
 	if (r.Status == tfe.RunPlanning || r.Status == tfe.RunPlannedAndSaved) && r.Plan.Status == tfe.PlanFinished {
 		hasChanges := r.IsDestroy ||
 			bytes.Contains(logs, []byte("1 to add")) ||


### PR DESCRIPTION
This removes the deprecated `io/ioutil` package from `internal/cloud` and its subpackages.

There is nothing user-facing, so a CHANGELOG entry isn't warranted.

https://github.com/opentffoundation/opentf/issues/313