### PR TITLE
internal/command: deprecate ioutil

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -841,12 +840,12 @@ func TestApply_plan_remoteState(t *testing.T) {
 
 	// State file should be not be installed
 	if _, err := os.Stat(filepath.Join(tmp, DefaultStateFilename)); err == nil {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 		t.Fatalf("State path should not exist: %s", string(data))
 	}
 
 	// Check that there is no remote state config
-	if src, err := ioutil.ReadFile(remoteStatePath); err == nil {
+	if src, err := os.ReadFile(remoteStatePath); err == nil {
 		t.Fatalf("has %s file; should not\n%s", remoteStatePath, src)
 	}
 }
@@ -854,7 +853,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 func TestApply_planWithVarFile(t *testing.T) {
 	varFileDir := testTempDir(t)
 	varFilePath := filepath.Join(varFileDir, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1373,7 +1372,7 @@ func TestApply_varFile(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1435,7 +1434,7 @@ func TestApply_varFileDefault(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1496,7 +1495,7 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars.json")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/command/arguments/default.go
+++ b/internal/command/arguments/default.go
@@ -5,14 +5,14 @@ package arguments
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 )
 
 // defaultFlagSet creates a FlagSet with the common settings to override
 // the flag package's noisy defaults.
 func defaultFlagSet(name string) *flag.FlagSet {
 	f := flag.NewFlagSet(name, flag.ContinueOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 	f.Usage = func() {}
 
 	return f

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -20,7 +19,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// make sure a vars file doesn't interfere
-	err := ioutil.WriteFile(DefaultVarsFilename, nil, 0644)
+	err := os.WriteFile(DefaultVarsFilename, nil, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -152,7 +151,7 @@ func loadConfigFile(path string) (*Config, tfdiags.Diagnostics) {
 	log.Printf("Loading CLI configuration from %s", path)
 
 	// Read the HCL file and prepare for parsing
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error reading %s: %s", path, err))
 		return result, diags
@@ -197,7 +196,7 @@ func loadConfigDir(path string) (*Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	result := &Config{}
 
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error reading %s: %s", path, err))
 		return result, diags

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -329,7 +328,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		return fmt.Errorf("unable to determine credentials file path: %s", err)
 	}
 
-	oldSrc, err := ioutil.ReadFile(filename)
+	oldSrc, err := os.ReadFile(filename)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("cannot read %s: %s", filename, err)
 	}
@@ -396,7 +395,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 	// the underlying OS/filesystem will allow.
 	{
 		dir, file := filepath.Split(filename)
-		f, err := ioutil.TempFile(dir, file)
+		f, err := os.CreateTemp(dir, file)
 		if err != nil {
 			return fmt.Errorf("cannot create temporary file to update credentials: %s", err)
 		}
@@ -454,7 +453,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 // this returns an empty set, reflecting that effectively no credentials are
 // stored there.
 func readHostsInCredentialsFile(filename string) map[svchost.Hostname]struct{} {
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		return nil
 	}

--- a/internal/command/clistate/local_state.go
+++ b/internal/command/clistate/local_state.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -290,7 +289,7 @@ func (s *LocalState) lockInfoPath() string {
 // lockInfo returns the data in a lock info file
 func (s *LocalState) lockInfo() (*statemgr.LockInfo, error) {
 	path := s.lockInfoPath()
-	infoData, err := ioutil.ReadFile(path)
+	infoData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +308,7 @@ func (s *LocalState) writeLockInfo(info *statemgr.LockInfo) error {
 	info.Path = s.Path
 	info.Created = time.Now().UTC()
 
-	err := ioutil.WriteFile(path, info.Marshal(), 0600)
+	err := os.WriteFile(path, info.Marshal(), 0600)
 	if err != nil {
 		return fmt.Errorf("could not write lock info for %q: %s", s.Path, err)
 	}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -920,7 +920,7 @@ func testCopyDir(t *testing.T, src, dst string) {
 		t.Fatal(err)
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return
 	}
@@ -930,16 +930,17 @@ func testCopyDir(t *testing.T, src, dst string) {
 		dstPath := filepath.Join(dst, entry.Name())
 
 		// If the entry is a symlink, we copy the contents
-		for entry.Mode()&os.ModeSymlink != 0 {
+		for entry.Type()&os.ModeSymlink != 0 {
 			target, err := os.Readlink(srcPath)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			entry, err = os.Stat(target)
+			fi, err := os.Stat(target)
 			if err != nil {
 				t.Fatal(err)
 			}
+			entry = fs.FileInfoToDirEntry(fi)
 		}
 
 		if entry.IsDir() {
@@ -1092,7 +1093,7 @@ func checkGoldenReference(t *testing.T, output *terminal.TestOutput, fixturePath
 		t.Fatalf("failed to open output file: %s", err)
 	}
 	defer wantFile.Close()
-	wantBytes, err := ioutil.ReadAll(wantFile)
+	wantBytes, err := io.ReadAll(wantFile)
 	if err != nil {
 		t.Fatalf("failed to read output file: %s", err)
 	}

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -5,7 +5,7 @@ package command
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -61,7 +61,7 @@ func TestConsole_tfvars(t *testing.T) {
 
 	// Write a terraform.tvars
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/command/e2etest/provider_dev_test.go
+++ b/internal/command/e2etest/provider_dev_test.go
@@ -5,7 +5,6 @@ package e2etest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func TestProviderDevOverrides(t *testing.T) {
 	providerExe := e2e.GoBuild("github.com/placeholderplaceholderplaceholder/opentf/internal/provider-simple/main", providerExePrefix)
 	t.Logf("temporary provider executable is %s", providerExe)
 
-	err := ioutil.WriteFile(filepath.Join(tf.WorkDir(), "dev.tfrc"), []byte(fmt.Sprintf(`
+	err := os.WriteFile(filepath.Join(tf.WorkDir(), "dev.tfrc"), []byte(fmt.Sprintf(`
 		provider_installation {
 			dev_overrides {
 				"example.com/test/test" = %q

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -4,7 +4,6 @@
 package e2etest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,7 +86,7 @@ func TestProviderTampering(t *testing.T) {
 		tf := e2e.NewBinary(t, terraformBin, seedDir)
 		workDir := tf.WorkDir()
 
-		err := ioutil.WriteFile(filepath.Join(workDir, "backend.tf"), []byte(localBackendConfig), 0600)
+		err := os.WriteFile(filepath.Join(workDir, "backend.tf"), []byte(localBackendConfig), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +121,7 @@ func TestProviderTampering(t *testing.T) {
 		tf := e2e.NewBinary(t, terraformBin, seedDir)
 		workDir := tf.WorkDir()
 
-		err := ioutil.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
+		err := os.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -142,7 +141,7 @@ func TestProviderTampering(t *testing.T) {
 		tf := e2e.NewBinary(t, terraformBin, seedDir)
 		workDir := tf.WorkDir()
 
-		err := ioutil.WriteFile(filepath.Join(workDir, "provider-tampering-base.tf"), []byte(`
+		err := os.WriteFile(filepath.Join(workDir, "provider-tampering-base.tf"), []byte(`
 			terraform {
 				required_providers {
 					null = {
@@ -177,7 +176,7 @@ func TestProviderTampering(t *testing.T) {
 		// of this error message for otehr sorts of inconsistency, but those
 		// are tested more thoroughly over in the "configs" package, which is
 		// ultimately responsible for that logic.
-		err := ioutil.WriteFile(filepath.Join(workDir, ".terraform.lock.hcl"), []byte(``), 0600)
+		err := os.WriteFile(filepath.Join(workDir, ".terraform.lock.hcl"), []byte(``), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -249,7 +248,7 @@ func TestProviderTampering(t *testing.T) {
 			t.Fatalf("unexpected plan failure\nstderr:\n%s", stderr)
 		}
 
-		err = ioutil.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
+		err = os.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/command/e2etest/unmanaged_test.go
+++ b/internal/command/e2etest/unmanaged_test.go
@@ -6,7 +6,7 @@ package e2etest
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -162,7 +162,7 @@ func TestUnmanagedSeparatePlan(t *testing.T) {
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Name:   "plugintest",
 			Level:  hclog.Trace,
-			Output: ioutil.Discard,
+			Output: io.Discard,
 		}),
 		Test: &plugin.ServeTestConfig{
 			Context:          ctx,
@@ -267,7 +267,7 @@ func TestUnmanagedSeparatePlan_proto5(t *testing.T) {
 		Logger: hclog.New(&hclog.LoggerOptions{
 			Name:   "plugintest",
 			Level:  hclog.Trace,
-			Output: ioutil.Discard,
+			Output: io.Discard,
 		}),
 		Test: &plugin.ServeTestConfig{
 			Context:          ctx,

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -173,7 +172,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout
 
 	log.Printf("[TRACE] opentf fmt: Formatting %s", path)
 
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to read %s", path))
 		return diags
@@ -200,7 +199,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout
 			fmt.Fprintln(w, path)
 		}
 		if c.write {
-			err := ioutil.WriteFile(path, result, 0644)
+			err := os.WriteFile(path, result, 0644)
 			if err != nil {
 				diags = diags.Append(fmt.Errorf("Failed to write %s", path))
 				return diags
@@ -231,7 +230,7 @@ func (c *FmtCommand) processDir(path string, stdout io.Writer) tfdiags.Diagnosti
 
 	log.Printf("[TRACE] opentf fmt: looking for files in %s", path)
 
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		switch {
 		case os.IsNotExist(err):
@@ -589,14 +588,14 @@ func (c *FmtCommand) Synopsis() string {
 }
 
 func bytesDiff(b1, b2 []byte, path string) (data []byte, err error) {
-	f1, err := ioutil.TempFile("", "")
+	f1, err := os.CreateTemp("", "")
 	if err != nil {
 		return
 	}
 	defer os.Remove(f1.Name())
 	defer f1.Close()
 
-	f2, err := ioutil.TempFile("", "")
+	f2, err := os.CreateTemp("", "")
 	if err != nil {
 		return
 	}

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,7 @@ func TestFmt_TestFiles(t *testing.T) {
 	const inSuffix = "_in.tftest.hcl"
 	const outSuffix = "_out.tftest.hcl"
 	const gotSuffix = "_got.tftest.hcl"
-	entries, err := ioutil.ReadDir("testdata/tftest-fmt")
+	entries, err := os.ReadDir("testdata/tftest-fmt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,15 +42,15 @@ func TestFmt_TestFiles(t *testing.T) {
 			inFile := filepath.Join("testdata", "tftest-fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "tftest-fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
-			input, err := ioutil.ReadFile(inFile)
+			input, err := os.ReadFile(inFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(wantFile)
+			want, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(gotFile, input, 0700)
+			err = os.WriteFile(gotFile, input, 0700)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -68,7 +67,7 @@ func TestFmt_TestFiles(t *testing.T) {
 				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
 			}
 
-			got, err := ioutil.ReadFile(gotFile)
+			got, err := os.ReadFile(gotFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -84,7 +83,7 @@ func TestFmt(t *testing.T) {
 	const inSuffix = "_in.tf"
 	const outSuffix = "_out.tf"
 	const gotSuffix = "_got.tf"
-	entries, err := ioutil.ReadDir("testdata/fmt")
+	entries, err := os.ReadDir("testdata/fmt")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,15 +106,15 @@ func TestFmt(t *testing.T) {
 			inFile := filepath.Join("testdata", "fmt", testName+inSuffix)
 			wantFile := filepath.Join("testdata", "fmt", testName+outSuffix)
 			gotFile := filepath.Join(tmpDir, testName+gotSuffix)
-			input, err := ioutil.ReadFile(inFile)
+			input, err := os.ReadFile(inFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			want, err := ioutil.ReadFile(wantFile)
+			want, err := os.ReadFile(wantFile)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = ioutil.WriteFile(gotFile, input, 0700)
+			err = os.WriteFile(gotFile, input, 0700)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -132,7 +131,7 @@ func TestFmt(t *testing.T) {
 				t.Fatalf("fmt command was unsuccessful:\n%s", ui.ErrorWriter.String())
 			}
 
-			got, err := ioutil.ReadFile(gotFile)
+			got, err := os.ReadFile(gotFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -174,7 +173,7 @@ func TestFmt_syntaxError(t *testing.T) {
 a = 1 +
 `
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "invalid.tf"), []byte(invalidSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "invalid.tf"), []byte(invalidSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +202,7 @@ func TestFmt_snippetInError(t *testing.T) {
 
 	backendSrc := `terraform {backend "s3" {}}`
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "backend.tf"), []byte(backendSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "backend.tf"), []byte(backendSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +237,7 @@ func TestFmt_manyArgs(t *testing.T) {
 	// Add a second file
 	secondSrc := `locals { x = 1 }`
 
-	err := ioutil.WriteFile(filepath.Join(tempDir, "second.tf"), []byte(secondSrc), 0644)
+	err := os.WriteFile(filepath.Join(tempDir, "second.tf"), []byte(secondSrc), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +474,7 @@ var fmtFixture = struct {
 func fmtFixtureWriteDir(t *testing.T) string {
 	dir := testTempDir(t)
 
-	err := ioutil.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0644)
+	err := os.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -278,7 +277,7 @@ func TestInit_backendUnset(t *testing.T) {
 		log.Printf("[TRACE] TestInit_backendUnset: beginning second init")
 
 		// Unset
-		if err := ioutil.WriteFile("main.tf", []byte(""), 0644); err != nil {
+		if err := os.WriteFile("main.tf", []byte(""), 0644); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 
@@ -892,7 +891,7 @@ func TestInit_backendReinitConfigToExtra(t *testing.T) {
 
 	// init again but remove the path option from the config
 	cfg := "terraform {\n  backend \"local\" {}\n}\n"
-	if err := ioutil.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
+	if err := os.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2101,7 +2100,7 @@ func TestInit_providerLockFile(t *testing.T) {
 	}
 
 	lockFile := ".terraform.lock.hcl"
-	buf, err := ioutil.ReadFile(lockFile)
+	buf, err := os.ReadFile(lockFile)
 	if err != nil {
 		t.Fatalf("failed to read dependency lock file %s: %s", lockFile, err)
 	}
@@ -2280,7 +2279,7 @@ provider "registry.terraform.io/hashicorp/test" {
 
 			// write input lockfile
 			lockFile := ".terraform.lock.hcl"
-			if err := ioutil.WriteFile(lockFile, []byte(tc.input), 0644); err != nil {
+			if err := os.WriteFile(lockFile, []byte(tc.input), 0644); err != nil {
 				t.Fatalf("failed to write input lockfile: %s", err)
 			}
 
@@ -2292,7 +2291,7 @@ provider "registry.terraform.io/hashicorp/test" {
 				t.Fatalf("expected error, got output: \n%s", ui.OutputWriter.String())
 			}
 
-			buf, err := ioutil.ReadFile(lockFile)
+			buf, err := os.ReadFile(lockFile)
 			if err != nil {
 				t.Fatalf("failed to read dependency lock file %s: %s", lockFile, err)
 			}

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -554,7 +554,7 @@ func (m *Meta) contextOpts() (*opentf.ContextOpts, error) {
 // See also command/arguments/default.go
 func (m *Meta) defaultFlagSet(n string) *flag.FlagSet {
 	f := flag.NewFlagSet(n, flag.ContinueOnError)
-	f.SetOutput(ioutil.Discard)
+	f.SetOutput(io.Discard)
 
 	// Set the default Usage to empty
 	f.Usage = func() {}
@@ -764,7 +764,7 @@ func (m *Meta) WorkspaceOverridden() (string, bool) {
 		return envVar, true
 	}
 
-	envData, err := ioutil.ReadFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile))
+	envData, err := os.ReadFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile))
 	current := string(bytes.TrimSpace(envData))
 	if current == "" {
 		current = backend.DefaultStateName
@@ -786,7 +786,7 @@ func (m *Meta) SetWorkspace(name string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile), []byte(name), 0644)
+	err = os.WriteFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile), []byte(name), 0644)
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -488,7 +487,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 	destination := destinationState.State()
 
 	// Save both to a temporary
-	td, err := ioutil.TempDir("", "terraform")
+	td, err := os.MkdirTemp("", "terraform")
 	if err != nil {
 		return false, fmt.Errorf("Error creating temporary directory: %s", err)
 	}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -365,7 +364,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -415,7 +414,7 @@ func TestMetaBackend_configureNewWithoutCopy(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -460,7 +459,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -531,7 +530,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -602,7 +601,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
@@ -1441,13 +1440,13 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if !isEmptyState(DefaultStateFilename) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename)
+		data, _ := os.ReadFile(DefaultStateFilename)
 		t.Fatal("state should not exist, but contains:\n", string(data))
 	}
 
 	// Verify a backup doesn't exist
 	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename + DefaultBackupExtension)
+		data, _ := os.ReadFile(DefaultStateFilename + DefaultBackupExtension)
 		t.Fatal("backup should not exist, but contains:\n", string(data))
 	}
 
@@ -1464,7 +1463,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 
 	// Verify no backup since it was empty to start
 	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
-		data, _ := ioutil.ReadFile(DefaultStateFilename + DefaultBackupExtension)
+		data, _ := os.ReadFile(DefaultStateFilename + DefaultBackupExtension)
 		t.Fatal("backup state should be empty, but contains:\n", string(data))
 	}
 }
@@ -1903,7 +1902,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 
 	// init again but remove the path option from the config
 	cfg := "terraform {\n  backend \"local\" {}\n}\n"
-	if err := ioutil.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
+	if err := os.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -275,7 +274,7 @@ func TestMeta_Workspace_invalidSelected(t *testing.T) {
 	if err := os.MkdirAll(DefaultDataDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte(workspace), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte(workspace), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -307,7 +306,7 @@ func TestMeta_process(t *testing.T) {
 	// they _aren't_ being interpreted by process, since that could otherwise
 	// cause them to be added more than once and mess up the precedence order.
 	defaultVarsfile := "terraform.tfvars"
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(d, defaultVarsfile),
 		[]byte(""),
 		0644)
@@ -315,7 +314,7 @@ func TestMeta_process(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	fileFirstAlphabetical := "a-file.auto.tfvars"
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, fileFirstAlphabetical),
 		[]byte(""),
 		0644)
@@ -323,7 +322,7 @@ func TestMeta_process(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	fileLastAlphabetical := "z-file.auto.tfvars"
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, fileLastAlphabetical),
 		[]byte(""),
 		0644)
@@ -332,7 +331,7 @@ func TestMeta_process(t *testing.T) {
 	}
 	// Regular tfvars files will not be autoloaded
 	fileIgnored := "ignored.tfvars"
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, fileIgnored),
 		[]byte(""),
 		0644)

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -74,7 +73,7 @@ func (m *Meta) collectVariableValues() (map[string]backend.UnparsedVariableValue
 		moreDiags := m.addVarsFromFile(defaultVarsFilenameJSON, opentf.ValueFromAutoFile, ret)
 		diags = diags.Append(moreDiags)
 	}
-	if infos, err := ioutil.ReadDir("."); err == nil {
+	if infos, err := os.ReadDir("."); err == nil {
 		// "infos" is already sorted by name, so we just need to filter it here.
 		for _, info := range infos {
 			name := info.Name()
@@ -137,7 +136,7 @@ func (m *Meta) collectVariableValues() (map[string]backend.UnparsedVariableValue
 func (m *Meta) addVarsFromFile(filename string, sourceType opentf.ValueSourceType, to map[string]backend.UnparsedVariableValue) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -989,7 +988,7 @@ func TestPlan_varFile(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1030,7 +1029,7 @@ func TestPlan_varFileDefault(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1069,7 +1068,7 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 	defer testChdir(t, td)()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(planVarFileWithDecl), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(planVarFileWithDecl), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/command/plugins_lock.go
+++ b/internal/command/plugins_lock.go
@@ -6,8 +6,8 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 )
 
 type pluginSHA256LockFile struct {
@@ -28,7 +28,7 @@ func (pf *pluginSHA256LockFile) Read() map[string][]byte {
 	// constraint verification fails during context creation.
 	digests := make(map[string][]byte)
 
-	buf, err := ioutil.ReadFile(pf.Filename)
+	buf, err := os.ReadFile(pf.Filename)
 	if err != nil {
 		// This is expected if the user runs any context-using command before
 		// running "terraform init".

--- a/internal/command/plugins_lock_test.go
+++ b/internal/command/plugins_lock_test.go
@@ -4,14 +4,13 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func TestPluginSHA256LockFile_Read(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "tf-pluginsha1lockfile-test-")
+	f, err := os.CreateTemp(t.TempDir(), "tf-pluginsha1lockfile-test-")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %s", err)
 	}

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -190,7 +189,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	updatedLocks := map[getproviders.Platform]*depsfile.Locks{}
 	selectedVersions := map[addrs.Provider]getproviders.Version{}
 	for _, platform := range platforms {
-		tempDir, err := ioutil.TempDir("", "terraform-providers-lock")
+		tempDir, err := os.MkdirTemp("", "terraform-providers-lock")
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -6,7 +6,6 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -316,7 +315,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 		// when running on Windows as of Go 1.13. We should revisit this once
 		// we're supporting network mirrors, to avoid having them briefly
 		// become corrupted during updates.
-		err = ioutil.WriteFile(filepath.Join(indexDir, "index.json"), mainIndexJSON, 0644)
+		err = os.WriteFile(filepath.Join(indexDir, "index.json"), mainIndexJSON, 0644)
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -334,7 +333,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 				// our control.
 				panic(fmt.Sprintf("failed to encode version index: %s", err))
 			}
-			err = ioutil.WriteFile(filepath.Join(indexDir, version.String()+".json"), versionIndexJSON, 0644)
+			err = os.WriteFile(filepath.Join(indexDir, version.String()+".json"), versionIndexJSON, 0644)
 			if err != nil {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -6,7 +6,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +36,7 @@ func TestProvidersSchema_error(t *testing.T) {
 
 func TestProvidersSchema_output(t *testing.T) {
 	fixtureDir := "testdata/providers-schema"
-	testDirs, err := ioutil.ReadDir(fixtureDir)
+	testDirs, err := os.ReadDir(fixtureDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestProvidersSchema_output(t *testing.T) {
 				t.Fatalf("err: %s", err)
 			}
 			defer wantFile.Close()
-			byteValue, err := ioutil.ReadAll(wantFile)
+			byteValue, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -322,7 +321,7 @@ func TestRefresh_outPath(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// Output path
-	outf, err := ioutil.TempFile(td, "tf")
+	outf, err := os.CreateTemp(td, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -438,7 +437,7 @@ func TestRefresh_varFile(t *testing.T) {
 	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := testTempFile(t)
-	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -480,7 +479,7 @@ func TestRefresh_varFileDefault(t *testing.T) {
 	p.GetProviderSchemaResponse = refreshVarFixtureSchema()
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
-	if err := ioutil.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
+	if err := os.WriteFile(varFilePath, []byte(refreshVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -559,7 +558,7 @@ func TestRefresh_backup(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// Output path
-	outf, err := ioutil.TempFile(td, "tf")
+	outf, err := os.CreateTemp(td, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -574,7 +573,7 @@ func TestRefresh_backup(t *testing.T) {
 	}
 
 	// Backup path
-	backupf, err := ioutil.TempFile(td, "tf")
+	backupf, err := os.CreateTemp(td, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -644,7 +643,7 @@ func TestRefresh_disableBackup(t *testing.T) {
 	statePath := testStateFile(t, state)
 
 	// Output path
-	outf, err := ioutil.TempFile(td, "tf")
+	outf, err := os.CreateTemp(td, "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -5,7 +5,7 @@ package command
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -527,7 +527,7 @@ func TestShow_state(t *testing.T) {
 
 func TestShow_json_output(t *testing.T) {
 	fixtureDir := "testdata/show-json"
-	testDirs, err := ioutil.ReadDir(fixtureDir)
+	testDirs, err := os.ReadDir(fixtureDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -576,7 +576,7 @@ func TestShow_json_output(t *testing.T) {
 				t.Fatalf("unexpected err: %s", err)
 			}
 			defer wantFile.Close()
-			byteValue, err := ioutil.ReadAll(wantFile)
+			byteValue, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("unexpected err: %s", err)
 			}
@@ -727,7 +727,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 		t.Fatalf("unexpected err: %s", err)
 	}
 	defer wantFile.Close()
-	byteValue, err := ioutil.ReadAll(wantFile)
+	byteValue, err := io.ReadAll(wantFile)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}
@@ -823,7 +823,7 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 		t.Fatalf("unexpected err: %s", err)
 	}
 	defer wantFile.Close()
-	byteValue, err := ioutil.ReadAll(wantFile)
+	byteValue, err := io.ReadAll(wantFile)
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}
@@ -840,7 +840,7 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 // similar test as above, without the plan
 func TestShow_json_output_state(t *testing.T) {
 	fixtureDir := "testdata/show-json-state"
-	testDirs, err := ioutil.ReadDir(fixtureDir)
+	testDirs, err := os.ReadDir(fixtureDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +910,7 @@ func TestShow_json_output_state(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 			defer wantFile.Close()
-			byteValue, err := ioutil.ReadAll(wantFile)
+			byteValue, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("unexpected err: %s", err)
 			}

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -5,7 +5,7 @@ package command
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -18,7 +18,7 @@ func TestStatePull(t *testing.T) {
 	testCopyDir(t, testFixturePath("state-pull-backend"), td)
 	defer testChdir(t, td)()
 
-	expected, err := ioutil.ReadFile("local-state.tfstate")
+	expected, err := os.ReadFile("local-state.tfstate")
 	if err != nil {
 		t.Fatalf("error reading state: %v", err)
 	}

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -5,7 +5,7 @@ package command
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -337,7 +337,7 @@ func TestValidate_json(t *testing.T) {
 				t.Fatalf("failed to open output file: %s", err)
 			}
 			defer wantFile.Close()
-			wantBytes, err := ioutil.ReadAll(wantFile)
+			wantBytes, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("failed to read output file: %s", err)
 			}

--- a/internal/command/views/json/diagnostic_test.go
+++ b/internal/command/views/json/diagnostic_test.go
@@ -6,7 +6,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -910,7 +910,7 @@ func TestNewDiagnostic(t *testing.T) {
 				t.Fatalf("failed to open golden file: %s", err)
 			}
 			defer wantFile.Close()
-			wantBytes, err := ioutil.ReadAll(wantFile)
+			wantBytes, err := io.ReadAll(wantFile)
 			if err != nil {
 				t.Fatalf("failed to read output file: %s", err)
 			}

--- a/internal/command/workdir/plugin_dirs.go
+++ b/internal/command/workdir/plugin_dirs.go
@@ -5,7 +5,6 @@ package workdir
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -36,7 +35,7 @@ func (d *Dir) ProviderLocalCacheDir() string {
 // non-empty list with no errors then the result totally replaces the default
 // search directories.
 func (d *Dir) ForcedPluginDirs() ([]string, error) {
-	raw, err := ioutil.ReadFile(filepath.Join(d.dataDir, PluginPathFilename))
+	raw, err := os.ReadFile(filepath.Join(d.dataDir, PluginPathFilename))
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -81,6 +80,6 @@ func (d *Dir) SetForcedPluginDirs(dirs []string) error {
 			return err
 		}
 
-		return ioutil.WriteFile(filePath, raw, 0644)
+		return os.WriteFile(filePath, raw, 0644)
 	}
 }

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +70,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// make sure a vars file doesn't interfere
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		DefaultVarsFilename,
 		[]byte(`foo = "bar"`),
 		0644,
@@ -119,7 +118,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	defer testChdir(t, td)()
 
 	// make sure a vars file doesn't interfere
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		DefaultVarsFilename,
 		[]byte(`foo = "bar"`),
 		0644,
@@ -302,7 +301,7 @@ func TestWorkspace_delete(t *testing.T) {
 	if err := os.MkdirAll(DefaultDataDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(DefaultDataDir, local.DefaultWorkspaceFile), []byte("test"), 0644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This replaces the deprecated `io/ioutil` package throughout `internal/command` and its subpackages.

There is nothing user-facing here that warrants a CHANGELOG entry.
https://github.com/opentffoundation/opentf/issues/313