### PR TITLE
internal/states: deprecate io/ioutil

### DIFF
--- a/internal/states/statefile/read.go
+++ b/internal/states/statefile/read.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	version "github.com/hashicorp/go-version"
@@ -60,7 +59,7 @@ func Read(r io.Reader) (*File, error) {
 	// We actually just buffer the whole thing in memory, because states are
 	// generally not huge and we need to do be able to sniff for a version
 	// number before full parsing.
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/states/statefile/roundtrip_test.go
+++ b/internal/states/statefile/roundtrip_test.go
@@ -5,7 +5,6 @@ package statefile
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -17,7 +16,7 @@ import (
 
 func TestRoundtrip(t *testing.T) {
 	const dir = "testdata/roundtrip"
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +36,7 @@ func TestRoundtrip(t *testing.T) {
 		outName := name + outSuffix
 
 		t.Run(name, func(t *testing.T) {
-			oSrcWant, err := ioutil.ReadFile(filepath.Join(dir, outName))
+			oSrcWant, err := os.ReadFile(filepath.Join(dir, outName))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -514,7 +513,7 @@ func (s *Filesystem) lockInfoPath() string {
 // lockInfo returns the data in a lock info file
 func (s *Filesystem) lockInfo() (*LockInfo, error) {
 	path := s.lockInfoPath()
-	infoData, err := ioutil.ReadFile(path)
+	infoData, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -534,7 +533,7 @@ func (s *Filesystem) writeLockInfo(info *LockInfo) error {
 	info.Created = time.Now().UTC()
 
 	log.Printf("[TRACE] statemgr.Filesystem: writing lock metadata to %s", path)
-	err := ioutil.WriteFile(path, info.Marshal(), 0600)
+	err := os.WriteFile(path, info.Marshal(), 0600)
 	if err != nil {
 		return fmt.Errorf("could not write lock info for %q: %s", s.readPath, err)
 	}

--- a/internal/states/statemgr/filesystem_test.go
+++ b/internal/states/statemgr/filesystem_test.go
@@ -4,7 +4,6 @@
 package statemgr
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -133,7 +132,7 @@ func TestFilesystem_writeWhileLocked(t *testing.T) {
 
 func TestFilesystem_pathOut(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -149,7 +148,7 @@ func TestFilesystem_pathOut(t *testing.T) {
 
 func TestFilesystem_backup(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -344,7 +343,7 @@ func TestFilesystem_impl(t *testing.T) {
 }
 
 func testFilesystem(t *testing.T) *Filesystem {
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("failed to create temporary file %s", err)
 	}
@@ -372,7 +371,7 @@ func testFilesystem(t *testing.T) *Filesystem {
 // Make sure we can refresh while the state is locked
 func TestFilesystem_refreshWhileLocked(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
-	f, err := ioutil.TempFile("", "tf")
+	f, err := os.CreateTemp("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This removes deprecated calls to `io/ioutil` from the `internal/states` package and subpackages.

There is nothing user-facing, so a CHANGELOG entry isn't warranted.

Part of issue #313
