### PR TITLE
Marshal plan#relevant_attributes in deterministic order

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -682,6 +682,11 @@ func (p *Plan) marshalRelevantAttrs(plan *plans.Plan) error {
 
 		p.RelevantAttributes = append(p.RelevantAttributes, ResourceAttr{addr, path})
 	}
+
+	sort.Slice(p.RelevantAttributes, func(i, j int) bool {
+		return p.RelevantAttributes[i].Resource < p.RelevantAttributes[j].Resource
+	})
+
 	return nil
 }
 

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -683,6 +683,8 @@ func (p *Plan) marshalRelevantAttrs(plan *plans.Plan) error {
 		p.RelevantAttributes = append(p.RelevantAttributes, ResourceAttr{addr, path})
 	}
 
+	// We sort the relevant attributes by resource address to make the output
+	// deterministic. Our own equivalence tests rely on it.
 	sort.Slice(p.RelevantAttributes, func(i, j int) bool {
 		return p.RelevantAttributes[i].Resource < p.RelevantAttributes[j].Resource
 	})

--- a/testing/equivalence-tests/outputs/data_read/plan.json
+++ b/testing/equivalence-tests/outputs/data_read/plan.json
@@ -205,15 +205,15 @@
   "relevant_attributes": [
     {
       "attribute": [
-        "id"
-      ],
-      "resource": "module.create.random_integer.random"
-    },
-    {
-      "attribute": [
         "string"
       ],
       "resource": "data.tfcoremock_simple_resource.read"
+    },
+    {
+      "attribute": [
+        "id"
+      ],
+      "resource": "module.create.random_integer.random"
     }
   ],
   "resource_changes": [


### PR DESCRIPTION
Closes #321

The order in which relevant attributes are stored in the plan is non-deterministic. It's not a biggie in general, but it could be important for some tooling, like our own equivalence testing. There's no harm in sorting these during JSON marshal.