### PR TITLE
Fixes broken links in md docs and bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
       value: |
         # Thank you for opening an issue.
 
-        The [OpenTF](https://github.com/placeholderplaceholderplaceholder/opentf) issue tracker is reserved for bug reports relating to the core OpenTF CLI application and configuration language.
+        The [OpenTF](https://github.com/opentffoundation/opentf) issue tracker is reserved for bug reports relating to the core OpenTF CLI application and configuration language.
 
         ## Filing a bug report
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Describe in detail the changes you are proposing, and the rationale.
 
 See the contributing guide:
 
-https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.github/CONTRIBUTING.md
+https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md
 
 -->
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,7 +4,7 @@ If you'd like to build OpenTF from source, you can do so using the Go build tool
 
 ## Prerequisites
 
-1. Ensure you've installed the Go language version specified in [`.go-version`](https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.go-version).
+1. Ensure you've installed the Go language version specified in [`.go-version`](.go-version).
 2. Clone this repository to a location of your choice.
 
 ## OpenTF Build Options

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If you wish to work on the OpenTF CLI source code, you'll first need to install 
 
 At this time the OpenTF development environment is targeting only Linux and Mac OS X systems. While OpenTF itself is compatible with Windows, unfortunately the unit test suite currently contains Unix-specific assumptions around maximum path lengths, path separators, etc.
 
-Refer to the file [`.go-version`](https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.go-version) to see which version of Go OpenTF is currently built with. Other versions will often work, but if you run into any build or testing problems please try with the specific Go version indicated. You can optionally simplify the installation of multiple specific versions of Go on your system by installing [`goenv`](https://github.com/syndbg/goenv), which reads `.go-version` and automatically selects the correct Go version.
+Refer to the file [`.go-version`](.go-version) to see which version of Go OpenTF is currently built with. Other versions will often work, but if you run into any build or testing problems please try with the specific Go version indicated. You can optionally simplify the installation of multiple specific versions of Go on your system by installing [`goenv`](https://github.com/syndbg/goenv), which reads `.go-version` and automatically selects the correct Go version.
 
 Use Git to clone this repository into a location of your choice. OpenTF is using [Go Modules](https://blog.golang.org/using-go-modules), and so you should *not* clone it inside your `GOPATH`.
 


### PR DESCRIPTION
## What changed

- Fixed broken link to the .go-version file in the md doc files
- Fixed broken links in the issue template

## Why do we need it

Housekeeping and consistency.

Closes #324 
