### PR TITLE
Change the CHANGELOG bot to add the reminder as a comment when PR is opened

### DIFF
--- a/.github/workflows/merged-pr.yml
+++ b/.github/workflows/merged-pr.yml
@@ -5,7 +5,7 @@ permissions:
 # only trigger on pull request closed events
 on:
   pull_request_target:
-    types: [ closed ]
+    types: [ opened ]
 
 jobs:
   merge_job:
@@ -20,5 +20,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Reminder for the merging maintainer: if this is a user-visible change, please update the changelog on the appropriate release branch."
+              body: "Reminder for the PR assignee: If this is a user-visible change, please update the changelog as part of the PR."
             })

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,4 +1,4 @@
-name: Merged Pull Request
+name: Pull Request Opened
 permissions:
   pull-requests: write
 
@@ -8,9 +8,7 @@ on:
     types: [ opened ]
 
 jobs:
-  merge_job:
-    # this job will only run if the PR has been merged
-    if: github.event.pull_request.merged == true
+  pr_open_job:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1


### PR DESCRIPTION
Change the CHANGELOG bot to write its message on PR open.
Also, change the message to indicate that we'd like the contributor themselves to update the CHANGELOG, as part of the PR

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes https://github.com/opentffoundation/opentf/issues/329

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

