### PR TITLE
internal/communicator: deprecate io/ioutil

### DIFF
--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -654,7 +653,7 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, size
 	if size == 0 {
 		// Create a temporary file where we can copy the contents of the src
 		// so that we can determine the length, since SCP is length-prefixed.
-		tf, err := ioutil.TempFile("", "terraform-upload")
+		tf, err := os.CreateTemp("", "terraform-upload")
 		if err != nil {
 			return fmt.Errorf("Error creating temporary file for upload: %s", err)
 		}

--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -607,7 +606,7 @@ func TestAccUploadFile(t *testing.T) {
 		t.Fatalf("error uploading file: %s", err)
 	}
 
-	data, err := ioutil.ReadFile(tmpFile)
+	data, err := os.ReadFile(tmpFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +640,7 @@ func TestAccHugeUploadFile(t *testing.T) {
 	size := int64(1 << 32)
 	source := io.LimitReader(rand.New(rand.NewSource(0)), size)
 
-	dest, err := ioutil.TempFile("", "communicator")
+	dest, err := os.CreateTemp("", "communicator")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -334,7 +333,7 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 		// generally wants to handle config data in-memory. Rather than making
 		// the known_hosts file an exception, write out the data to a temporary
 		// file to create the HostKeyCallback.
-		tf, err := ioutil.TempFile("", "tf-known_hosts")
+		tf, err := os.CreateTemp("", "tf-known_hosts")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp known_hosts file: %s", err)
 		}
@@ -525,7 +524,7 @@ func idKeyData(id string) [][]byte {
 	}
 
 	for _, p := range paths {
-		d, err := ioutil.ReadFile(p)
+		d, err := os.ReadFile(p)
 		if err != nil {
 			log.Printf("[DEBUG] error reading %q: %s", p, err)
 			continue

--- a/internal/communicator/ssh/ssh_test.go
+++ b/internal/communicator/ssh/ssh_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func TestFindKeyData(t *testing.T) {
 	if err := os.Rename(id+".pub", "saved.pub"); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(id+".pub", []byte("not a public key"), 0600); err != nil {
+	if err := os.WriteFile(id+".pub", []byte("not a public key"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -55,7 +54,7 @@ func TestFindKeyData(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(id, []byte("encrypted private key"), 0600); err != nil {
+	if err := os.WriteFile(id, []byte("encrypted private key"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +94,7 @@ func generateSSHKey(t *testing.T, idFile string) ssh.PublicKey {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(idFile+".pub", ssh.MarshalAuthorizedKey(pub), 0600)
+	err = os.WriteFile(idFile+".pub", ssh.MarshalAuthorizedKey(pub), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This removes all instances of the deprecated `io/ioutil` package from `internal/communicator` and its subpackages.

There is nothing user-facing that warrants a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313