### PR TITLE
internal/configs: deprecate io/ioutil

### DIFF
--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -5,7 +5,7 @@ package configs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -162,7 +162,7 @@ func TestBuildConfigChildModuleBackend(t *testing.T) {
 
 func TestBuildConfigInvalidModules(t *testing.T) {
 	testDir := "testdata/config-diagnostics"
-	dirs, err := ioutil.ReadDir(testDir)
+	dirs, err := os.ReadDir(testDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,8 +203,8 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 			// expected location in the source, but is not required.
 			// The literal characters `\n` are replaced with newlines, but
 			// otherwise the string is unchanged.
-			expectedErrs := readDiags(ioutil.ReadFile(filepath.Join(testDir, name, "errors")))
-			expectedWarnings := readDiags(ioutil.ReadFile(filepath.Join(testDir, name, "warnings")))
+			expectedErrs := readDiags(os.ReadFile(filepath.Join(testDir, name, "errors")))
+			expectedWarnings := readDiags(os.ReadFile(filepath.Join(testDir, name, "warnings")))
 
 			_, buildDiags := BuildConfig(mod, ModuleWalkerFunc(
 				func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {

--- a/internal/configs/configload/copy_dir_test.go
+++ b/internal/configs/configload/copy_dir_test.go
@@ -4,7 +4,6 @@
 package configload
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func TestCopyDir_symlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestCopyDir_symlink_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -4,7 +4,6 @@
 package configload
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -23,7 +22,7 @@ import (
 func NewLoaderForTests(t *testing.T) (*Loader, func()) {
 	t.Helper()
 
-	modulesDir, err := ioutil.TempDir("", "tf-configs")
+	modulesDir, err := os.MkdirTemp("", "tf-configs")
 	if err != nil {
 		t.Fatalf("failed to create temporary modules dir: %s", err)
 		return nil, func() {}

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -4,7 +4,7 @@
 package configs
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestLoadModuleCall(t *testing.T) {
-	src, err := ioutil.ReadFile("testdata/invalid-files/module-calls.tf")
+	src, err := os.ReadFile("testdata/invalid-files/module-calls.tf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -5,7 +5,7 @@ package configs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,7 +24,7 @@ import (
 // module element contents. More detailed assertions may be made on some subset
 // of these configuration files in other tests.
 func TestParserLoadConfigDirSuccess(t *testing.T) {
-	dirs, err := ioutil.ReadDir("testdata/valid-modules")
+	dirs, err := os.ReadDir("testdata/valid-modules")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 
 	// The individual files in testdata/valid-files should also work
 	// when loaded as modules.
-	files, err := ioutil.ReadDir("testdata/valid-files")
+	files, err := os.ReadDir("testdata/valid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(fmt.Sprintf("%s as module", name), func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/valid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/valid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -184,7 +184,7 @@ func TestParserLoadConfigDirWithTests_ReturnsWarnings(t *testing.T) {
 // diagnostics in particular. More detailed assertions may be made on some subset
 // of these configuration files in other tests.
 func TestParserLoadConfigDirFailure(t *testing.T) {
-	dirs, err := ioutil.ReadDir("testdata/invalid-modules")
+	dirs, err := os.ReadDir("testdata/invalid-modules")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestParserLoadConfigDirFailure(t *testing.T) {
 
 	// The individual files in testdata/valid-files should also work
 	// when loaded as modules.
-	files, err := ioutil.ReadDir("testdata/invalid-files")
+	files, err := os.ReadDir("testdata/invalid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestParserLoadConfigDirFailure(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(fmt.Sprintf("%s as module", name), func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/invalid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/invalid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -6,7 +6,7 @@ package configs
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,7 +24,7 @@ import (
 // file element contents. More detailed assertions may be made on some subset
 // of these configuration files in other tests.
 func TestParserLoadConfigFileSuccess(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/valid-files")
+	files, err := os.ReadDir("testdata/valid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestParserLoadConfigFileSuccess(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/valid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/valid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -60,7 +60,7 @@ func TestParserLoadConfigFileSuccess(t *testing.T) {
 // assertions should be made on some subset of these configuration files in
 // other tests.
 func TestParserLoadConfigFileFailure(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/invalid-files")
+	files, err := os.ReadDir("testdata/invalid-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestParserLoadConfigFileFailure(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/invalid-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/invalid-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -136,7 +136,7 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Filename, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata", test.Filename))
+			src, err := os.ReadFile(filepath.Join("testdata", test.Filename))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -170,7 +170,7 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 // file element contents in spite of those warnings. More detailed assertions
 // may be made on some subset of these configuration files in other tests.
 func TestParserLoadConfigFileWarning(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/warning-files")
+	files, err := os.ReadDir("testdata/warning-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func TestParserLoadConfigFileWarning(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/warning-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/warning-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -235,7 +235,7 @@ func TestParserLoadConfigFileWarning(t *testing.T) {
 // file element contents in spite of those errors. More detailed assertions
 // may be made on some subset of these configuration files in other tests.
 func TestParserLoadConfigFileError(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata/error-files")
+	files, err := os.ReadDir("testdata/error-files")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestParserLoadConfigFileError(t *testing.T) {
 	for _, info := range files {
 		name := info.Name()
 		t.Run(name, func(t *testing.T) {
-			src, err := ioutil.ReadFile(filepath.Join("testdata/error-files", name))
+			src, err := os.ReadFile(filepath.Join("testdata/error-files", name))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/configs/provider_test.go
+++ b/internal/configs/provider_test.go
@@ -4,7 +4,7 @@
 package configs
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestProviderReservedNames(t *testing.T) {
-	src, err := ioutil.ReadFile("testdata/invalid-files/provider-reserved.tf")
+	src, err := os.ReadFile("testdata/invalid-files/provider-reserved.tf")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This replaces all instances of the deprecated `io/ioutil` package within `internal/configs` and its subpackages.

There is nothing user-facing that warrants a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313