### PR TITLE
internal/copy: deprecate io/ioutil

### DIFF
--- a/internal/copy/copy_dir_test.go
+++ b/internal/copy/copy_dir_test.go
@@ -4,7 +4,6 @@
 package copy
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func TestCopyDir_symlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(subModuleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestCopyDir_symlink_file(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
+	err = os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("hello"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This replaces all instances of the deprecated `io/ioutil` package within `internal/copy` and its subpackages.

There are no user-facing changes that warrant a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313