### PR TITLE
internal/e2e: deprecate io/ioutil

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -165,7 +164,7 @@ func (b *binary) OpenFile(path ...string) (*os.File, error) {
 // directory.
 func (b *binary) ReadFile(path ...string) ([]byte, error) {
 	flatPath := b.Path(path...)
-	return ioutil.ReadFile(flatPath)
+	return os.ReadFile(flatPath)
 }
 
 // FileExists is a helper for easily testing whether a particular file
@@ -235,7 +234,7 @@ func (b *binary) SetLocalState(state *states.State) error {
 
 func GoBuild(pkgPath, tmpPrefix string) string {
 	dir, prefix := filepath.Split(tmpPrefix)
-	tmpFile, err := ioutil.TempFile(dir, prefix)
+	tmpFile, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This replaces usage of the deprecated `io/ioutil` package in the `internal/e2e` package.

There are no user-facing changes that warrant a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313