### PR TITLE
internal/getproviders: deprecate io/ioutil

### DIFF
--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/addrs"
@@ -153,7 +152,7 @@ func FakePackageMeta(provider addrs.Provider, version Version, protocols Version
 // should call the callback even if this function returns an error, because
 // some error conditions leave a partially-created file on disk.
 func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protocols VersionList, target Platform, execFilename string) (PackageMeta, func(), error) {
-	f, err := ioutil.TempFile("", "terraform-getproviders-fake-package-")
+	f, err := os.CreateTemp("", "terraform-getproviders-fake-package-")
 	if err != nil {
 		return PackageMeta{}, func() {}, err
 	}

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -443,7 +443,7 @@ func (c *registryClient) getFile(url *url.URL) ([]byte, error) {
 		return nil, fmt.Errorf("%s returned from %s", resp.Status, HostFromRequest(resp.Request))
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return data, err
 	}


### PR DESCRIPTION
This replaces the deprecated `io/ioutil` package in `internal/getproviders`.

There are no user-facing changes that warrant a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313

