### PR TITLE
internal/lang/funcs: deprecate io/ioutil

### DIFF
--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -6,7 +6,7 @@ package funcs
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"unicode/utf8"
@@ -426,7 +426,7 @@ func readFileBytes(baseDir, path string, marks cty.ValueMarks) ([]byte, error) {
 	}
 	defer f.Close()
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}


### PR DESCRIPTION
This replaces the deprecated `io/ioutil` package used in `internal/lang/functions`.

There are no user-facing changes that warrant a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313