### PR TITLE
internal/plugin: deprecate io/ioutil

### DIFF
--- a/internal/plugin/discovery/find.go
+++ b/internal/plugin/discovery/find.go
@@ -4,7 +4,6 @@
 package discovery
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -51,7 +50,7 @@ func findPluginPaths(kind string, dirs []string) []string {
 	ret := make([]string, 0, len(dirs))
 
 	for _, dir := range dirs {
-		items, err := ioutil.ReadDir(dir)
+		items, err := os.ReadDir(dir)
 		if err != nil {
 			// Ignore missing dirs, non-dirs, etc
 			continue


### PR DESCRIPTION
This removes all usage of the deprecated `io/ioutil` package throughout `internal/plugin` and its subpackages.

There is nothing user-facing here, I don't think a CHANGELOG entry is warranted.

https://github.com/opentffoundation/opentf/issues/313