### PR TITLE
 internal/registry: deprecate io/ioutil

### DIFF
--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -228,7 +228,7 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 	defer resp.Body.Close()
 
 	// there should be no body, but save it for logging
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body from registry: %s", err)
 	}


### PR DESCRIPTION
This removes all usage of the deprecated `io/ioutil package` throughout `internal/registry` and its subpackages.

There is nothing user-facing here, I don't think a CHANGELOG entry is warranted.

https://github.com/opentffoundation/opentf/issues/313