### PR TITLE
internal/providercache: deprecate io/ioutil

### DIFF
--- a/internal/providercache/cached_provider.go
+++ b/internal/providercache/cached_provider.go
@@ -5,7 +5,7 @@ package providercache
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -104,7 +104,7 @@ func (cp *CachedProvider) HashV1() (getproviders.Hash, error) {
 // slashes and backslashes as long as the separators are consistent within a
 // particular path string.
 func (cp *CachedProvider) ExecutableFile() (string, error) {
-	infos, err := ioutil.ReadDir(cp.PackageDir)
+	infos, err := os.ReadDir(cp.PackageDir)
 	if err != nil {
 		// If the directory itself doesn't exist or isn't readable then we
 		// can't access an executable in it.

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -6,7 +6,6 @@ package providercache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 		return nil, fmt.Errorf("unsuccessful request to %s: %s", url, resp.Status)
 	}
 
-	f, err := ioutil.TempFile("", "terraform-provider")
+	f, err := os.CreateTemp("", "terraform-provider")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open temporary file to download from %s: %w", url, err)
 	}


### PR DESCRIPTION
This removes all usage of the deprecated `io/ioutil` package throughout `internal/providercache` and its subpackages.

There is nothing user-facing here, I don't think a CHANGELOG entry is warranted.

https://github.com/opentffoundation/opentf/issues/313