### PR TITLE
internal/legacy: deprecate io/ioutil

### DIFF
--- a/internal/legacy/opentf/state.go
+++ b/internal/legacy/opentf/state.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -1958,7 +1957,7 @@ func ReadState(src io.Reader) (*State, error) {
 
 	// If we are JSON we buffer the whole thing in memory so we can read it twice.
 	// This is suboptimal, but will work for now.
-	jsonBytes, err := ioutil.ReadAll(buf)
+	jsonBytes, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, fmt.Errorf("Reading state file failed: %v", err)
 	}


### PR DESCRIPTION
This removes all usage of the deprecated `io/ioutil` package throughout `internal/legacy` and its subpackages.

There is nothing user-facing here, I don't think a CHANGELOG entry is warranted.

https://github.com/opentffoundation/opentf/issues/313