### PR TITLE
internal/modsdir: deprecate io/ioutil

### DIFF
--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -71,7 +70,7 @@ type manifestSnapshotFile struct {
 }
 
 func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This removes all usage of the deprecated `io/ioutil` package throughout `internal/modsdir` and its subpackages.

There is nothing user-facing here, I don't think a CHANGELOG entry is warranted.

https://github.com/opentffoundation/opentf/issues/313