### PR TITLE
internal/states/statefile: make ErrNoState a type

### DIFF
--- a/internal/plans/planfile/reader.go
+++ b/internal/plans/planfile/reader.go
@@ -150,7 +150,7 @@ func (r *Reader) ReadPlan() (*plans.Plan, error) {
 // represents the "PriorState" as defined in plans.Plan.
 //
 // If the plan file contains no embedded state file, the returned error is
-// statefile.ErrNoState.
+// &statefile.ErrNoState{}.
 func (r *Reader) ReadStateFile() (*statefile.File, error) {
 	for _, file := range r.zip.File {
 		if file.Name == tfstateFilename {
@@ -161,14 +161,14 @@ func (r *Reader) ReadStateFile() (*statefile.File, error) {
 			return statefile.Read(r)
 		}
 	}
-	return nil, errUnusable(statefile.ErrNoState)
+	return nil, errUnusable(&statefile.ErrNoState{})
 }
 
 // ReadPrevStateFile reads the previous state file embedded in the plan file, which
 // represents the "PrevRunState" as defined in plans.Plan.
 //
 // If the plan file contains no embedded previous state file, the returned error is
-// statefile.ErrNoState.
+// &statefile.ErrNoState{}.
 func (r *Reader) ReadPrevStateFile() (*statefile.File, error) {
 	for _, file := range r.zip.File {
 		if file.Name == tfstatePreviousFilename {
@@ -179,7 +179,7 @@ func (r *Reader) ReadPrevStateFile() (*statefile.File, error) {
 			return statefile.Read(r)
 		}
 	}
-	return nil, errUnusable(statefile.ErrNoState)
+	return nil, errUnusable(&statefile.ErrNoState{})
 }
 
 // ReadConfigSnapshot reads the configuration snapshot embedded in the plan

--- a/internal/states/statefile/read.go
+++ b/internal/states/statefile/read.go
@@ -5,7 +5,6 @@ package statefile
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,7 +16,11 @@ import (
 )
 
 // ErrNoState is returned by ReadState when the state file is empty.
-var ErrNoState = errors.New("no state")
+type ErrNoState struct{}
+
+func (e *ErrNoState) Error() string {
+	return "no state"
+}
 
 // ErrUnusableState is an error wrapper to indicate that we *think* the input
 // represents state data, but can't use it for some reason (as explained in the
@@ -51,7 +54,7 @@ func Read(r io.Reader) (*File, error) {
 	// Some callers provide us a "typed nil" *os.File here, which would
 	// cause us to panic below if we tried to use it.
 	if f, ok := r.(*os.File); ok && f == nil {
-		return nil, ErrNoState
+		return nil, &ErrNoState{}
 	}
 
 	var diags tfdiags.Diagnostics
@@ -70,7 +73,7 @@ func Read(r io.Reader) (*File, error) {
 	}
 
 	if len(src) == 0 {
-		return nil, ErrNoState
+		return nil, &ErrNoState{}
 	}
 
 	state, err := readState(src)

--- a/internal/states/statefile/read_test.go
+++ b/internal/states/statefile/read_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package statefile
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestReadErrNoState(t *testing.T) {
+	emptyFile, err := os.Open("testdata/read/empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer emptyFile.Close()
+
+	_, err = Read(emptyFile)
+	if !errors.Is(err, &ErrNoState{}) {
+		t.Fatalf("expected ErrNoState, got %T", err)
+	}
+
+	nilFile, err := os.Open("")
+	if err == nil {
+		t.Fatal("wrongly succeeded in opening non-existent file")
+	}
+
+	_, err = Read(nilFile)
+	if !errors.Is(err, &ErrNoState{}) {
+		t.Fatalf("expected ErrNoState, got %T", err)
+	}
+}

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -6,6 +6,7 @@ package statemgr
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -296,7 +297,7 @@ func (s *Filesystem) refreshState() error {
 	f, err := statefile.Read(reader)
 	// if there's no state then a nil file is fine
 	if err != nil {
-		if err != statefile.ErrNoState {
+		if !errors.Is(err, &statefile.ErrNoState{}) {
 			return err
 		}
 		log.Printf("[TRACE] statemgr.Filesystem: snapshot file has nil snapshot, but that's okay")
@@ -484,7 +485,7 @@ func (s *Filesystem) createStateFiles() error {
 	// of our backup file if we write a change later.
 	s.backupFile, err = statefile.Read(s.stateFileOut)
 	if err != nil {
-		if err != statefile.ErrNoState {
+		if !errors.Is(err, &statefile.ErrNoState{}) {
 			return err
 		}
 		log.Printf("[TRACE] statemgr.Filesystem: no previously-stored snapshot exists")


### PR DESCRIPTION
Relying on `errors.New()` for custom errors means that they all end up with the type `*errors.errorString`, so they can't be used with type assertions, they can't be meaningfully wrapped, and you can't see where they came from by using `%T` in a log.

This changes `statefile.ErrNoState` to be a type instead of just a variable. It also adds some test coverage.

Where is a good example of a correct license header to use in the file `read_test.go`?

https://github.com/opentffoundation/opentf/issues/363