### PR TITLE
Backport from 1.5.x: Require valid module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ BUG FIXES:
 * Transitive dependencies were lost during apply when the referenced resource expanded into zero instances ([#33403](https://github.com/hashicorp/terraform/issues/33403))
 * OpenTF will no longer override SSH settings in local git configuration when installing modules. ([#33592](https://github.com/hashicorp/terraform/issues/33592))
 * Handle file-operation errors in `internal/states/statemgr`. ([#278](https://github.com/opentffoundation/opentf/issues/278))
+* `opentf init`: OpenTF will no longer allow downloading remote modules to invalid paths. ([#356](https://github.com/opentffoundation/opentf/issues/356))
 
 ## Previous Releases
 

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apparentlymart/go-versions/versions"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/addrs"
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/configs"
@@ -159,6 +160,13 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 				// Because we descend into modules which have errors, we need
 				// to look out for this case, but the config loader's
 				// diagnostics will report the error later.
+				return nil, nil, diags
+			}
+
+			if !hclsyntax.ValidIdentifier(req.Name) {
+				// A module with an invalid name shouldn't be installed at all. This is
+				// mostly a concern for remote modules, since we need to be able to convert
+				// the name to a valid path.
 				return nil, nil, diags
 			}
 

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -139,6 +139,26 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 	}
 }
 
+func TestModuleInstaller_invalidModuleName(t *testing.T) {
+	fixtureDir := filepath.Clean("testdata/invalid-module-name")
+	dir, done := tempChdir(t, fixtureDir)
+	defer done()
+
+	hooks := &testInstallHooks{}
+
+	modulesDir := filepath.Join(dir, ".terraform/modules")
+
+	loader, close := configload.NewLoaderForTests(t)
+	defer close()
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
+	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks)
+	if !diags.HasErrors() {
+		t.Fatal("expected error")
+	} else {
+		assertDiagnosticSummary(t, diags, "Invalid module instance name")
+	}
+}
+
 func TestModuleInstaller_packageEscapeError(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/load-module-package-escape")
 	dir, done := tempChdir(t, fixtureDir)

--- a/internal/initwd/testdata/invalid-module-name/child/main.tf
+++ b/internal/initwd/testdata/invalid-module-name/child/main.tf
@@ -1,0 +1,3 @@
+output "boop" {
+  value = "beep"
+}

--- a/internal/initwd/testdata/invalid-module-name/main.tf
+++ b/internal/initwd/testdata/invalid-module-name/main.tf
@@ -1,0 +1,3 @@
+module "../invalid" {
+  source  = "./child"
+}


### PR DESCRIPTION
Signed-off-by: Elbaz <eranelbaz97+github@gmail.com>
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #356
See PR under MPL 1.5.x: https://github.com/hashicorp/terraform/pull/33769

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `opentf init`: OpenTF will no longer allow downloading remote modules to invalid paths
