### PR TITLE
Backport from 1.5.x: Ignore unknown check results on decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 UPGRADE NOTES:
 * The `cloud` and `remote` backends will no longer default to `app.terraform.io` hostname and will require the hostname to be explicitly specified ([#291](https://github.com/opentffoundation/opentf/pull/291));
 * The `login` and `logout` commands will no longer default to `app.terraform.io` hostname and will require the hostname to be explicitly provided as a command-line argument ([#291](https://github.com/opentffoundation/opentf/pull/291));
+* prevent future possible incompatibility with states that include unknown `check` block result kinds.  ([#355](https://github.com/opentffoundation/opentf/pull/355));
 
 NEW FEATURES:
 * `opentf test`: The previously experimental `opentf test` command has been moved out of experimental. This comes with a significant change in how OpenTF tests are written and executed.

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -525,7 +525,11 @@ func decodeCheckResultsV4(in []checkResultsV4) (*states.CheckResults, tfdiags.Di
 	for _, aggrIn := range in {
 		objectKind := decodeCheckableObjectKindV4(aggrIn.ObjectKind)
 		if objectKind == addrs.CheckableKindInvalid {
-			diags = diags.Append(fmt.Errorf("unsupported checkable object kind %q", aggrIn.ObjectKind))
+			// We cannot decode a future unknown check result kind, but
+			// for forwards compatibility we need not treat this as an
+			// error. Eliding unknown check results will not result in
+			// significant data loss and allows us to maintain state file
+			// interoperability in the 1.x series.
 			continue
 		}
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #355

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- prevent future possible incompatibility with states that include unknown `check` block result kinds.
