### PR TITLE
GitHub Actions workflow to close stale Pull Requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           operations-per-run: 100
           # By default, issues and pull requests are marked as stale after 60 days of inactivity.
-          # We will override this for PRs to 30 days since we do not with to touch issues in this job.
+          # We will override this for PRs to 30 days since we do not wish to touch issues in this job.
           days-before-stale: -1
           days-before-close: -1
           days-before-pr-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Stale Issues & Pull Requests
+
+on:
+  schedule:
+    # Run every day at 12:00 UTC
+    - cron: 0 12 * * *
+
+jobs:
+  pull_request:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+        with:
+          # By default, issues and pull requests are marked as stale after 60 days of inactivity.
+          # We will override this for PRs to 30 days since we do not with to touch issues in this job.
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-message: >-
+            This Pull Request has been marked as stale since it has not had any
+            activity in the last 30 days. Either remove the stale label or add a
+            comment to keep it open, otherwise it will be closed in 7 days.
+          close-pr-message: >-
+            This Pull Request has been automatically closed since it has not had
+            any activity 7 days after being marked as stale. Feel free to reopen
+            the PR if you still want to work on it.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
+          operations-per-run: 100
           # By default, issues and pull requests are marked as stale after 60 days of inactivity.
           # We will override this for PRs to 30 days since we do not with to touch issues in this job.
           days-before-stale: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,8 @@ jobs:
           days-before-close: -1
           days-before-pr-stale: 30
           days-before-pr-close: 7
+          exempt-pr-labels: will-address
+          stale-pr-label: stale
           stale-pr-message: >-
             This Pull Request has been marked as stale since it has not had any
             activity in the last 30 days. Please commit some changes or add a

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,9 +21,10 @@ jobs:
           days-before-pr-close: 7
           stale-pr-message: >-
             This Pull Request has been marked as stale since it has not had any
-            activity in the last 30 days. Either remove the stale label or add a
-            comment to keep it open, otherwise it will be closed in 7 days.
+            activity in the last 30 days. Please commit some changes or add a
+            comment to keep the PR open, otherwise it will be closed after 7
+            days.
           close-pr-message: >-
             This Pull Request has been automatically closed since it has not had
-            any activity 7 days after being marked as stale. Feel free to reopen
-            the PR if you still want to work on it.
+            any activity 7 days after being marked as stale. If you still wish
+            to work on this, please let us know and we will reopen it.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

This commit creates a new GitHub Actions workflow using the actions/stale reusable action provided by GitHub. It creates a new workflow containing a single job which targets Pull Requests. In future, a new job can be added that targets issues or alternatively the same job can handle both PRs and issues.

After 30 days of inactivity, the PR has a "stale" label added.  If no activity happens for a further 7 days, the PR is closed. This does not delete the branches for closed Pull Requests, although can be configured to do so.

This action dependency is licensed under MIT and is provided and maintained by the team at GitHub.

I have tested this configuration in my own repo and appears to work well - https://github.com/rsturla/eternal-images/pull/20

Note: Included in this PR is an escape hatch for PRs you wish to bypass this rule.  If there are PRs you know you want to merge but have been around for a while, you can add the `will-address` label.  Not sure if you will use this, but it's helpful to have this escape hatch accessible.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #375 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

Add a GitHub Actions workflow to close stale Pull Requests.


<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 
