### PR TITLE
Backport of clarify types and link to Type Constraints pagedit types into v1.5

### DIFF
--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -21,13 +21,17 @@ The OpenTF language uses the following types for its values:
   numbers like `15` and fractional values like `6.283185`.
 * `bool`: a boolean value, either `true` or `false`. `bool` values can be used in conditional
   logic.
-* `list` (or `tuple`): a sequence of values, like
-  `["us-west-1a", "us-west-1c"]`. Elements in a list or tuple are identified by
-  consecutive whole numbers, starting with zero.
+* `list`: a sequence of values, like `["us-west-1a", "us-west-1c"]`. Elements in a list are
+  identified by consecutive whole numbers, starting with zero.
+* `set`: a collection of unique values that do not have any secondary identifiers or ordering.
 * `map` (or `object`): a group of values identified by named labels, like
   `{name = "Mabel", age = 52}`.
 
-Strings, numbers, and bools are sometimes called _primitive types._ Lists/tuples and maps/objects are sometimes called _complex types,_ _structural types,_ or _collection types._
+Strings, numbers, and bools are sometimes called _primitive types._ Lists and sets are forms
+of tuples. Maps are a form of objects. Tuples and maps are sometimes called _complex types,_
+_structural types,_ or _collection types._ See
+[Type Constraints](/terraform/language/expressions/type-constraints) for a more detailed
+description of complex types.
 
 Finally, there is one special value that has _no_ type:
 

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -24,13 +24,13 @@ The OpenTF language uses the following types for its values:
 * `list`: a sequence of values, like `["us-west-1a", "us-west-1c"]`. Elements in a list are
   identified by consecutive whole numbers, starting with zero.
 * `set`: a collection of unique values that do not have any secondary identifiers or ordering.
-* `map` (or `object`): a group of values identified by named labels, like
+* `map`: a group of values identified by named labels, like
   `{name = "Mabel", age = 52}`.
 
 Strings, numbers, and bools are sometimes called _primitive types._ Lists and sets are forms
 of tuples. Maps are a form of objects. Tuples and maps are sometimes called _complex types,_
 _structural types,_ or _collection types._ See
-[Type Constraints](/terraform/language/expressions/type-constraints) for a more detailed
+[Type Constraints](/opentf/language/expressions/type-constraints) for a more detailed
 description of complex types.
 
 Finally, there is one special value that has _no_ type:


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #358

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
