### PR TITLE
backend/remote-state/http: tests support go1.21

### DIFF
--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -49,7 +49,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Create the request
 	req, err := retryablehttp.NewRequest(method, url.String(), reader)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to make %s HTTP request: %s", what, err)
+		return nil, fmt.Errorf("Failed to make %s HTTP request: %w", what, err)
 	}
 	// Set up basic auth
 	if c.Username != "" {
@@ -70,7 +70,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Make the request
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to %s: %v", what, err)
+		return nil, fmt.Errorf("Failed to %s: %w", what, err)
 	}
 
 	return resp, nil


### PR DESCRIPTION
This fixes the test that started failing between go1.20 and 1.21.

Changes in `tls/crypto` to conform with RFC 5246 and RFC 8446 are described:

> For TLS 1.3 connections, if the server is configured to require client authentication using [RequireAnyClientCert](https://tip.golang.org/pkg/crypto/tls/#RequireAnyClientCert) or [RequireAndVerifyClientCert](https://tip.golang.org/pkg/crypto/tls/#RequireAndVerifyClientCert), and the client does not provide any certificate, the server will now return the "certificate required" alert.

This broke an error string comparison that expected the old message that included "bad certificate."

This uses the `%w` directive to wrap the errors from `httpclient.httpRequest()` so that they can be unwrapped in `TestMTLSServer_NoCertFails()`.

This is one of the issues holding back building with go1.21. This does not change `.go-version` to go1.21.

part of https://github.com/opentffoundation/opentf/issues/284
relates to #284
There are no user-facing changes that warrant a CHANGELOG entry.