### PR TITLE
internal/backend: wrap formatted errors

### DIFF
--- a/internal/backend/remote-state/azure/arm_client.go
+++ b/internal/backend/remote-state/azure/arm_client.go
@@ -99,7 +99,7 @@ func buildArmClient(ctx context.Context, config BackendConfig) (*ArmClient, erro
 	}
 	armConfig, err := builder.Build()
 	if err != nil {
-		return nil, fmt.Errorf("Error building ARM Config: %+v", err)
+		return nil, fmt.Errorf("Error building ARM Config: %w", err)
 	}
 
 	oauthConfig, err := armConfig.BuildOAuthConfig(env.ActiveDirectoryEndpoint)
@@ -144,7 +144,7 @@ func (c ArmClient) getBlobClient(ctx context.Context) (*blobs.Client, error) {
 		log.Printf("[DEBUG] Building the Blob Client from a SAS Token")
 		storageAuth, err := autorest.NewSASTokenAuthorizer(c.sasToken)
 		if err != nil {
-			return nil, fmt.Errorf("Error building Authorizer: %+v", err)
+			return nil, fmt.Errorf("Error building SAS Token Authorizer: %w", err)
 		}
 
 		blobsClient := blobs.NewWithEnvironment(c.environment)
@@ -163,7 +163,7 @@ func (c ArmClient) getBlobClient(ctx context.Context) (*blobs.Client, error) {
 		log.Printf("[DEBUG] Building the Blob Client from an Access Token (using user credentials)")
 		keys, err := c.storageAccountsClient.ListKeys(ctx, c.resourceGroupName, c.storageAccountName, "")
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving keys for Storage Account %q: %s", c.storageAccountName, err)
+			return nil, fmt.Errorf("Error retrieving keys for Storage Account %q: %w", c.storageAccountName, err)
 		}
 
 		if keys.Keys == nil {
@@ -176,7 +176,7 @@ func (c ArmClient) getBlobClient(ctx context.Context) (*blobs.Client, error) {
 
 	storageAuth, err := autorest.NewSharedKeyAuthorizer(c.storageAccountName, accessKey, autorest.SharedKey)
 	if err != nil {
-		return nil, fmt.Errorf("Error building Authorizer: %+v", err)
+		return nil, fmt.Errorf("Error building Shared Key Authorizer: %w", err)
 	}
 
 	blobsClient := blobs.NewWithEnvironment(c.environment)
@@ -189,7 +189,7 @@ func (c ArmClient) getContainersClient(ctx context.Context) (*containers.Client,
 		log.Printf("[DEBUG] Building the Container Client from a SAS Token")
 		storageAuth, err := autorest.NewSASTokenAuthorizer(c.sasToken)
 		if err != nil {
-			return nil, fmt.Errorf("Error building Authorizer: %+v", err)
+			return nil, fmt.Errorf("Error building SAS Token Authorizer: %w", err)
 		}
 
 		containersClient := containers.NewWithEnvironment(c.environment)
@@ -208,7 +208,7 @@ func (c ArmClient) getContainersClient(ctx context.Context) (*containers.Client,
 		log.Printf("[DEBUG] Building the Container Client from an Access Token (using user credentials)")
 		keys, err := c.storageAccountsClient.ListKeys(ctx, c.resourceGroupName, c.storageAccountName, "")
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving keys for Storage Account %q: %s", c.storageAccountName, err)
+			return nil, fmt.Errorf("Error retrieving keys for Storage Account %q: %w", c.storageAccountName, err)
 		}
 
 		if keys.Keys == nil {
@@ -221,7 +221,7 @@ func (c ArmClient) getContainersClient(ctx context.Context) (*containers.Client,
 
 	storageAuth, err := autorest.NewSharedKeyAuthorizer(c.storageAccountName, accessKey, autorest.SharedKey)
 	if err != nil {
-		return nil, fmt.Errorf("Error building Authorizer: %+v", err)
+		return nil, fmt.Errorf("Error building Shared Key Authorizer: %w", err)
 	}
 
 	containersClient := containers.NewWithEnvironment(c.environment)

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -110,7 +110,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		lockInfo.Operation = "init"
 		lockId, err := client.Lock(lockInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to lock azure state: %s", err)
+			return nil, fmt.Errorf("failed to lock azure state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -80,7 +80,7 @@ func (c *RemoteClient) Put(data []byte) error {
 
 		log.Printf("[DEBUG] Snapshotting existing Blob %q (Container %q / Account %q)", c.keyName, c.containerName, c.accountName)
 		if _, err := c.giovanniBlobClient.Snapshot(ctx, c.accountName, c.containerName, c.keyName, snapshotInput); err != nil {
-			return fmt.Errorf("error snapshotting Blob %q (Container %q / Account %q): %+v", c.keyName, c.containerName, c.accountName, err)
+			return fmt.Errorf("error snapshotting Blob %q (Container %q / Account %q): %w", c.keyName, c.containerName, c.accountName, err)
 		}
 
 		log.Print("[DEBUG] Created blob snapshot")
@@ -253,7 +253,7 @@ func (c *RemoteClient) Unlock(id string) error {
 
 	lockInfo, err := c.getLockInfo()
 	if err != nil {
-		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %s", err)
+		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %w", err)
 		return lockErr
 	}
 	lockErr.Info = lockInfo
@@ -265,7 +265,7 @@ func (c *RemoteClient) Unlock(id string) error {
 
 	c.leaseID = lockInfo.ID
 	if err := c.writeLockInfo(nil); err != nil {
-		lockErr.Err = fmt.Errorf("failed to delete lock info from metadata: %s", err)
+		lockErr.Err = fmt.Errorf("failed to delete lock info from metadata: %w", err)
 		return lockErr
 	}
 

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -347,7 +347,7 @@ func (c *RemoteClient) getLockInfo() (*statemgr.LockInfo, error) {
 	li := &statemgr.LockInfo{}
 	err = json.Unmarshal(pair.Value, li)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling lock info: %s", err)
+		return nil, fmt.Errorf("error unmarshaling lock info: %w", err)
 	}
 
 	return li, nil

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -178,7 +178,7 @@ func (c *remoteClient) getObject(cosFile string) (exists bool, data []byte, chec
 	rsp, err := c.cosClient.Object.Get(c.cosContext, cosFile, nil)
 	if rsp == nil {
 		log.Printf("[DEBUG] getObject %s: error: %v", cosFile, err)
-		err = fmt.Errorf("failed to open file at %v: %v", cosFile, err)
+		err = fmt.Errorf("failed to open file at %v: %w", cosFile, err)
 		return
 	}
 	defer rsp.Body.Close()
@@ -188,7 +188,7 @@ func (c *remoteClient) getObject(cosFile string) (exists bool, data []byte, chec
 		if rsp.StatusCode == 404 {
 			err = nil
 		} else {
-			err = fmt.Errorf("failed to open file at %v: %v", cosFile, err)
+			err = fmt.Errorf("failed to open file at %v: %w", cosFile, err)
 		}
 		return
 	}
@@ -204,7 +204,7 @@ func (c *remoteClient) getObject(cosFile string) (exists bool, data []byte, chec
 	data, err = io.ReadAll(rsp.Body)
 	log.Printf("[DEBUG] getObject %s: data length: %d", cosFile, len(data))
 	if err != nil {
-		err = fmt.Errorf("failed to open file at %v: %v", cosFile, err)
+		err = fmt.Errorf("failed to open file at %v: %w", cosFile, err)
 		return
 	}
 
@@ -239,13 +239,13 @@ func (c *remoteClient) putObject(cosFile string, data []byte) error {
 	rsp, err := c.cosClient.Object.Put(c.cosContext, cosFile, r, opt)
 	if rsp == nil {
 		log.Printf("[DEBUG] putObject %s: error: %v", cosFile, err)
-		return fmt.Errorf("failed to save file to %v: %v", cosFile, err)
+		return fmt.Errorf("failed to save file to %v: %w", cosFile, err)
 	}
 	defer rsp.Body.Close()
 
 	log.Printf("[DEBUG] putObject %s: code: %d, error: %v", cosFile, rsp.StatusCode, err)
 	if err != nil {
-		return fmt.Errorf("failed to save file to %v: %v", cosFile, err)
+		return fmt.Errorf("failed to save file to %v: %w", cosFile, err)
 	}
 
 	return nil
@@ -256,7 +256,7 @@ func (c *remoteClient) deleteObject(cosFile string) error {
 	rsp, err := c.cosClient.Object.Delete(c.cosContext, cosFile)
 	if rsp == nil {
 		log.Printf("[DEBUG] deleteObject %s: error: %v", cosFile, err)
-		return fmt.Errorf("failed to delete file %v: %v", cosFile, err)
+		return fmt.Errorf("failed to delete file %v: %w", cosFile, err)
 	}
 	defer rsp.Body.Close()
 
@@ -266,7 +266,7 @@ func (c *remoteClient) deleteObject(cosFile string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to delete file %v: %v", cosFile, err)
+		return fmt.Errorf("failed to delete file %v: %w", cosFile, err)
 	}
 
 	return nil
@@ -300,7 +300,7 @@ func (c *remoteClient) putBucket() error {
 	rsp, err := c.cosClient.Bucket.Put(c.cosContext, nil)
 	if rsp == nil {
 		log.Printf("[DEBUG] putBucket %s: error: %v", c.bucket, err)
-		return fmt.Errorf("failed to create bucket %v: %v", c.bucket, err)
+		return fmt.Errorf("failed to create bucket %v: %w", c.bucket, err)
 	}
 	defer rsp.Body.Close()
 
@@ -310,7 +310,7 @@ func (c *remoteClient) putBucket() error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to create bucket %v: %v", c.bucket, err)
+		return fmt.Errorf("failed to create bucket %v: %w", c.bucket, err)
 	}
 
 	return nil
@@ -325,7 +325,7 @@ func (c *remoteClient) deleteBucket(recursive bool) error {
 				return nil
 			}
 			log.Printf("[DEBUG] deleteBucket %s: empty bucket error: %v", c.bucket, err)
-			return fmt.Errorf("failed to empty bucket %v: %v", c.bucket, err)
+			return fmt.Errorf("failed to empty bucket %v: %w", c.bucket, err)
 		}
 		for _, v := range obs {
 			c.deleteObject(v.Key)
@@ -335,7 +335,7 @@ func (c *remoteClient) deleteBucket(recursive bool) error {
 	rsp, err := c.cosClient.Bucket.Delete(c.cosContext)
 	if rsp == nil {
 		log.Printf("[DEBUG] deleteBucket %s: error: %v", c.bucket, err)
-		return fmt.Errorf("failed to delete bucket %v: %v", c.bucket, err)
+		return fmt.Errorf("failed to delete bucket %v: %w", c.bucket, err)
 	}
 	defer rsp.Body.Close()
 
@@ -345,7 +345,7 @@ func (c *remoteClient) deleteBucket(recursive bool) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to delete bucket %v: %v", c.bucket, err)
+		return fmt.Errorf("failed to delete bucket %v: %w", c.bucket, err)
 	}
 
 	return nil
@@ -423,7 +423,7 @@ func (c *remoteClient) CreateTag(key, value string) error {
 	_, err := c.tagClient.CreateTag(request)
 	log.Printf("[DEBUG] create tag %s:%s: error: %v", key, value, err)
 	if err != nil {
-		return fmt.Errorf("failed to create tag: %s -> %s: %s", key, value, err)
+		return fmt.Errorf("failed to create tag: %s -> %s: %w", key, value, err)
 	}
 
 	return nil
@@ -438,7 +438,7 @@ func (c *remoteClient) DeleteTag(key, value string) error {
 	_, err := c.tagClient.DeleteTag(request)
 	log.Printf("[DEBUG] delete tag %s:%s: error: %v", key, value, err)
 	if err != nil {
-		return fmt.Errorf("failed to delete tag: %s -> %s: %s", key, value, err)
+		return fmt.Errorf("failed to delete tag: %s -> %s: %w", key, value, err)
 	}
 
 	return nil

--- a/internal/backend/remote-state/gcs/backend.go
+++ b/internal/backend/remote-state/gcs/backend.go
@@ -167,7 +167,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		// to mirror how the provider works, we accept the file path or the contents
 		contents, err := backend.ReadPathOrContents(creds)
 		if err != nil {
-			return fmt.Errorf("Error loading credentials: %s", err)
+			return fmt.Errorf("Error loading credentials: %w", err)
 		}
 
 		if !json.Valid([]byte(contents)) {
@@ -217,7 +217,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 	client, err := storage.NewClient(b.storageContext, opts...)
 	if err != nil {
-		return fmt.Errorf("storage.NewClient() failed: %v", err)
+		return fmt.Errorf("storage.NewClient() failed: %w", err)
 	}
 
 	b.storageClient = client
@@ -227,7 +227,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	if key != "" {
 		kc, err := backend.ReadPathOrContents(key)
 		if err != nil {
-			return fmt.Errorf("Error loading encryption key: %s", err)
+			return fmt.Errorf("Error loading encryption key: %w", err)
 		}
 
 		// The GCS client expects a customer supplied encryption key to be
@@ -238,7 +238,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		// https://github.com/GoogleCloudPlatform/google-cloud-go/blob/def681/storage/storage.go#L1181
 		k, err := base64.StdEncoding.DecodeString(kc)
 		if err != nil {
-			return fmt.Errorf("Error decoding encryption key: %s", err)
+			return fmt.Errorf("Error decoding encryption key: %w", err)
 		}
 		b.encryptionKey = k
 	}

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -35,19 +35,19 @@ func (c *remoteClient) Get() (payload *remote.Payload, err error) {
 		if err == storage.ErrObjectNotExist {
 			return nil, nil
 		} else {
-			return nil, fmt.Errorf("Failed to open state file at %v: %v", c.stateFileURL(), err)
+			return nil, fmt.Errorf("Failed to open state file at %v: %w", c.stateFileURL(), err)
 		}
 	}
 	defer stateFileReader.Close()
 
 	stateFileContents, err := io.ReadAll(stateFileReader)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read state file from %v: %v", c.stateFileURL(), err)
+		return nil, fmt.Errorf("Failed to read state file from %v: %w", c.stateFileURL(), err)
 	}
 
 	stateFileAttrs, err := c.stateFile().Attrs(c.storageContext)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read state file attrs from %v: %v", c.stateFileURL(), err)
+		return nil, fmt.Errorf("Failed to read state file attrs from %v: %w", c.stateFileURL(), err)
 	}
 
 	result := &remote.Payload{
@@ -70,7 +70,7 @@ func (c *remoteClient) Put(data []byte) error {
 		return stateFileWriter.Close()
 	}()
 	if err != nil {
-		return fmt.Errorf("Failed to upload state to %v: %v", c.stateFileURL(), err)
+		return fmt.Errorf("Failed to upload state to %v: %w", c.stateFileURL(), err)
 	}
 
 	return nil
@@ -78,7 +78,7 @@ func (c *remoteClient) Put(data []byte) error {
 
 func (c *remoteClient) Delete() error {
 	if err := c.stateFile().Delete(c.storageContext); err != nil {
-		return fmt.Errorf("Failed to delete state file %v: %v", c.stateFileURL(), err)
+		return fmt.Errorf("Failed to delete state file %v: %w", c.stateFileURL(), err)
 	}
 
 	return nil
@@ -106,7 +106,7 @@ func (c *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	}()
 
 	if err != nil {
-		return "", c.lockError(fmt.Errorf("writing %q failed: %v", c.lockFileURL(), err))
+		return "", c.lockError(fmt.Errorf("writing %q failed: %w", c.lockFileURL(), err))
 	}
 
 	info.ID = strconv.FormatInt(w.Attrs().Generation, 10)

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -180,7 +180,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	address := data.Get("address").(string)
 	updateURL, err := url.Parse(address)
 	if err != nil {
-		return fmt.Errorf("failed to parse address URL: %s", err)
+		return fmt.Errorf("failed to parse address URL: %w", err)
 	}
 	if updateURL.Scheme != "http" && updateURL.Scheme != "https" {
 		return fmt.Errorf("address must be HTTP or HTTPS")
@@ -193,7 +193,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		var err error
 		lockURL, err = url.Parse(v.(string))
 		if err != nil {
-			return fmt.Errorf("failed to parse lockAddress URL: %s", err)
+			return fmt.Errorf("failed to parse lockAddress URL: %w", err)
 		}
 		if lockURL.Scheme != "http" && lockURL.Scheme != "https" {
 			return fmt.Errorf("lockAddress must be HTTP or HTTPS")
@@ -207,7 +207,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		var err error
 		unlockURL, err = url.Parse(v.(string))
 		if err != nil {
-			return fmt.Errorf("failed to parse unlockAddress URL: %s", err)
+			return fmt.Errorf("failed to parse unlockAddress URL: %w", err)
 		}
 		if unlockURL.Scheme != "http" && unlockURL.Scheme != "https" {
 			return fmt.Errorf("unlockAddress must be HTTP or HTTPS")

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -49,7 +49,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Create the request
 	req, err := retryablehttp.NewRequest(method, url.String(), reader)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to make %s HTTP request: %s", what, err)
+		return nil, fmt.Errorf("Failed to make %s HTTP request: %w", what, err)
 	}
 	// Set up basic auth
 	if c.Username != "" {
@@ -70,7 +70,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Make the request
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to %s: %v", what, err)
+		return nil, fmt.Errorf("Failed to %s: %w", what, err)
 	}
 
 	return resp, nil
@@ -171,7 +171,7 @@ func (c *httpClient) Get() (*remote.Payload, error) {
 	// Read in the body
 	buf := bytes.NewBuffer(nil)
 	if _, err := io.Copy(buf, resp.Body); err != nil {
-		return nil, fmt.Errorf("Failed to read remote state: %s", err)
+		return nil, fmt.Errorf("Failed to read remote state: %w", err)
 	}
 
 	// Create the payload
@@ -189,7 +189,7 @@ func (c *httpClient) Get() (*remote.Payload, error) {
 		md5, err := base64.StdEncoding.DecodeString(raw)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"Failed to decode Content-MD5 '%s': %s", raw, err)
+				"Failed to decode Content-MD5 '%s': %w", raw, err)
 		}
 
 		payload.MD5 = md5

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -135,7 +135,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		lockInfo.Operation = "init"
 		lockID, err := s.Lock(lockInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to lock inmem state: %s", err)
+			return nil, fmt.Errorf("failed to lock inmem state: %w", err)
 		}
 		defer s.Unlock(lockID)
 

--- a/internal/backend/remote-state/kubernetes/backend.go
+++ b/internal/backend/remote-state/kubernetes/backend.go
@@ -208,7 +208,7 @@ func (b Backend) KubernetesSecretClient() (dynamic.ResourceInterface, error) {
 
 	client, err := dynamic.NewForConfig(b.config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to configure: %s", err)
+		return nil, fmt.Errorf("Failed to configure: %w", err)
 	}
 
 	b.kubernetesSecretClient = client.Resource(secretResource).Namespace(b.namespace)
@@ -388,7 +388,7 @@ func tryLoadingConfigFile(d *schema.ResourceData) (*restclient.Config, error) {
 			log.Printf("[INFO] Unable to load config file as it doesn't exist at %q", pathErr.Path)
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to initialize kubernetes configuration: %s", err)
+		return nil, fmt.Errorf("Failed to initialize kubernetes configuration: %w", err)
 	}
 
 	log.Printf("[INFO] Successfully initialized config")

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -110,14 +110,14 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 				const unlockErrMsg = `%v
 				Additionally, unlocking the state in Kubernetes failed:
 
-				Error message: %q
+				Error message: %w
 				Lock ID (gen): %v
 				Secret Name: %v
 
 				You may have to force-unlock this state in order to use it again.
 				The Kubernetes backend acquires a lock during initialization to ensure
 				the initial state file is created.`
-				return fmt.Errorf(unlockErrMsg, baseErr, err.Error(), lockID, secretName)
+				return fmt.Errorf(unlockErrMsg, baseErr, err, lockID, secretName)
 			}
 
 			return baseErr

--- a/internal/backend/remote-state/oss/backend.go
+++ b/internal/backend/remote-state/oss/backend.go
@@ -435,13 +435,13 @@ func (b *Backend) getOSSEndpointByRegion(access_key, secret_key, security_token,
 
 	locationClient, err := location.NewClientWithOptions(region, getSdkConfig(), credentials.NewStsTokenCredential(access_key, secret_key, security_token))
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the location client: %#v", err)
+		return nil, fmt.Errorf("unable to initialize the location client: %w", err)
 
 	}
 	locationClient.AppendUserAgent(httpclient.DefaultApplicationName, TerraformVersion)
 	endpointsResponse, err := locationClient.DescribeEndpoints(args)
 	if err != nil {
-		return nil, fmt.Errorf("describe oss endpoint using region: %#v got an error: %#v", region, err)
+		return nil, fmt.Errorf("describe oss endpoint using region: %#v got an error: %w", region, err)
 	}
 	return endpointsResponse, nil
 }
@@ -532,7 +532,7 @@ func (a *Invoker) Run(f func() error) error {
 			catcher.RetryCount--
 
 			if catcher.RetryCount <= 0 {
-				return fmt.Errorf("retry timeout and got an error: %#v", err)
+				return fmt.Errorf("retry timeout and got an error: %w", err)
 			} else {
 				time.Sleep(time.Duration(catcher.RetryWaitSeconds) * time.Second)
 				return a.Run(f)
@@ -629,20 +629,20 @@ func getAuthCredentialByEcsRoleName(ecsRoleName string) (accessKey, secretKey, t
 	requestUrl := securityCredURL + ecsRoleName
 	httpRequest, err := http.NewRequest(requests.GET, requestUrl, strings.NewReader(""))
 	if err != nil {
-		err = fmt.Errorf("build sts requests err: %s", err.Error())
+		err = fmt.Errorf("build sts requests err: %w", err)
 		return
 	}
 	httpClient := &http.Client{}
 	httpResponse, err := httpClient.Do(httpRequest)
 	if err != nil {
-		err = fmt.Errorf("get Ecs sts token err : %s", err.Error())
+		err = fmt.Errorf("get Ecs sts token err: %w", err)
 		return
 	}
 
 	response := responses.NewCommonResponse()
 	err = responses.Unmarshal(response, httpResponse, "")
 	if err != nil {
-		err = fmt.Errorf("unmarshal Ecs sts token response err : %s", err.Error())
+		err = fmt.Errorf("unmarshal Ecs sts token response err: %w", err)
 		return
 	}
 
@@ -653,12 +653,12 @@ func getAuthCredentialByEcsRoleName(ecsRoleName string) (accessKey, secretKey, t
 	var data interface{}
 	err = json.Unmarshal(response.GetHttpContentBytes(), &data)
 	if err != nil {
-		err = fmt.Errorf("refresh Ecs sts token err, json.Unmarshal fail: %s", err.Error())
+		err = fmt.Errorf("refresh Ecs sts token err, json.Unmarshal fail: %w", err)
 		return
 	}
 	code, err := jmespath.Search("Code", data)
 	if err != nil {
-		err = fmt.Errorf("refresh Ecs sts token err, fail to get Code: %s", err.Error())
+		err = fmt.Errorf("refresh Ecs sts token err, fail to get Code: %w", err)
 		return
 	}
 	if code.(string) != "Success" {
@@ -667,17 +667,17 @@ func getAuthCredentialByEcsRoleName(ecsRoleName string) (accessKey, secretKey, t
 	}
 	accessKeyId, err := jmespath.Search("AccessKeyId", data)
 	if err != nil {
-		err = fmt.Errorf("refresh Ecs sts token err, fail to get AccessKeyId: %s", err.Error())
+		err = fmt.Errorf("refresh Ecs sts token err, fail to get AccessKeyId: %w", err)
 		return
 	}
 	accessKeySecret, err := jmespath.Search("AccessKeySecret", data)
 	if err != nil {
-		err = fmt.Errorf("refresh Ecs sts token err, fail to get AccessKeySecret: %s", err.Error())
+		err = fmt.Errorf("refresh Ecs sts token err, fail to get AccessKeySecret: %w", err)
 		return
 	}
 	securityToken, err := jmespath.Search("SecurityToken", data)
 	if err != nil {
-		err = fmt.Errorf("refresh Ecs sts token err, fail to get SecurityToken: %s", err.Error())
+		err = fmt.Errorf("refresh Ecs sts token err, fail to get SecurityToken: %w", err)
 		return
 	}
 

--- a/internal/backend/remote-state/oss/client.go
+++ b/internal/backend/remote-state/oss/client.go
@@ -99,7 +99,7 @@ func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 func (c *RemoteClient) Put(data []byte) error {
 	bucket, err := c.ossClient.Bucket(c.bucketName)
 	if err != nil {
-		return fmt.Errorf("error getting bucket: %#v", err)
+		return fmt.Errorf("error getting bucket: %w", err)
 	}
 
 	body := bytes.NewReader(data)
@@ -116,7 +116,7 @@ func (c *RemoteClient) Put(data []byte) error {
 
 	if body != nil {
 		if err := bucket.PutObject(c.stateFile, body, options...); err != nil {
-			return fmt.Errorf("failed to upload state %s: %#v", c.stateFile, err)
+			return fmt.Errorf("failed to upload state %s: %w", c.stateFile, err)
 		}
 	}
 
@@ -124,7 +124,7 @@ func (c *RemoteClient) Put(data []byte) error {
 	if err := c.putMD5(sum[:]); err != nil {
 		// if this errors out, we unfortunately have to error out altogether,
 		// since the next Get will inevitably fail.
-		return fmt.Errorf("failed to store state MD5: %s", err)
+		return fmt.Errorf("failed to store state MD5: %w", err)
 	}
 	return nil
 }
@@ -132,13 +132,13 @@ func (c *RemoteClient) Put(data []byte) error {
 func (c *RemoteClient) Delete() error {
 	bucket, err := c.ossClient.Bucket(c.bucketName)
 	if err != nil {
-		return fmt.Errorf("error getting bucket %s: %#v", c.bucketName, err)
+		return fmt.Errorf("error getting bucket %s: %w", c.bucketName, err)
 	}
 
 	log.Printf("[DEBUG] Deleting remote state from OSS: %#v", c.stateFile)
 
 	if err := bucket.DeleteObject(c.stateFile); err != nil {
-		return fmt.Errorf("error deleting state %s: %#v", c.stateFile, err)
+		return fmt.Errorf("error deleting state %s: %w", c.stateFile, err)
 	}
 
 	if err := c.deleteMD5(); err != nil {
@@ -189,10 +189,10 @@ func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 		PutRowChange: putParams,
 	})
 	if err != nil {
-		err = fmt.Errorf("invoking PutRow got an error: %#v", err)
+		err = fmt.Errorf("invoking PutRow got an error: %w", err)
 		lockInfo, infoErr := c.getLockInfo()
 		if infoErr != nil {
-			err = multierror.Append(err, fmt.Errorf("\ngetting lock info got an error: %#v", infoErr))
+			err = multierror.Append(err, fmt.Errorf("\ngetting lock info got an error: %w", infoErr))
 		}
 		lockErr := &statemgr.LockError{
 			Err:  err,
@@ -367,7 +367,7 @@ func (c *RemoteClient) Unlock(id string) error {
 
 	lockInfo, err := c.getLockInfo()
 	if err != nil {
-		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %s", err)
+		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %w", err)
 		return lockErr
 	}
 	lockErr.Info = lockInfo
@@ -410,11 +410,11 @@ func (c *RemoteClient) lockPath() string {
 func (c *RemoteClient) getObj() (*remote.Payload, error) {
 	bucket, err := c.ossClient.Bucket(c.bucketName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting bucket %s: %#v", c.bucketName, err)
+		return nil, fmt.Errorf("error getting bucket %s: %w", c.bucketName, err)
 	}
 
 	if exist, err := bucket.IsObjectExist(c.stateFile); err != nil {
-		return nil, fmt.Errorf("estimating object %s is exist got an error: %#v", c.stateFile, err)
+		return nil, fmt.Errorf("estimating object %s is exist got an error: %w", c.stateFile, err)
 	} else if !exist {
 		return nil, nil
 	}
@@ -422,12 +422,12 @@ func (c *RemoteClient) getObj() (*remote.Payload, error) {
 	var options []oss.Option
 	output, err := bucket.GetObject(c.stateFile, options...)
 	if err != nil {
-		return nil, fmt.Errorf("error getting object: %#v", err)
+		return nil, fmt.Errorf("error getting object: %w", err)
 	}
 
 	buf := bytes.NewBuffer(nil)
 	if _, err := io.Copy(buf, output); err != nil {
-		return nil, fmt.Errorf("failed to read remote state: %s", err)
+		return nil, fmt.Errorf("failed to read remote state: %w", err)
 	}
 	sum := md5.Sum(buf.Bytes())
 	payload := &remote.Payload{

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -86,13 +86,13 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		lockInfo.Operation = "init"
 		lockId, err := stateMgr.Lock(lockInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to lock state in Postgres: %s", err)
+			return nil, fmt.Errorf("failed to lock state in Postgres: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
 		lockUnlock := func(parent error) error {
 			if err := stateMgr.Unlock(lockId); err != nil {
-				return fmt.Errorf(`error unlocking Postgres state: %s`, err)
+				return fmt.Errorf("error unlocking Postgres state: %w", err)
 			}
 			return parent
 		}

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -133,7 +133,7 @@ func (c *RemoteClient) get() (*remote.Payload, error) {
 
 	buf := bytes.NewBuffer(nil)
 	if _, err := io.Copy(buf, output.Body); err != nil {
-		return nil, fmt.Errorf("Failed to read remote state: %s", err)
+		return nil, fmt.Errorf("Failed to read remote state: %w", err)
 	}
 
 	sum := md5.Sum(buf.Bytes())
@@ -183,14 +183,14 @@ func (c *RemoteClient) Put(data []byte) error {
 
 	_, err := c.s3Client.PutObject(i)
 	if err != nil {
-		return fmt.Errorf("failed to upload state: %s", err)
+		return fmt.Errorf("failed to upload state: %w", err)
 	}
 
 	sum := md5.Sum(data)
 	if err := c.putMD5(sum[:]); err != nil {
 		// if this errors out, we unfortunately have to error out altogether,
 		// since the next Get will inevitably fail.
-		return fmt.Errorf("failed to store state MD5: %s", err)
+		return fmt.Errorf("failed to store state MD5: %w", err)
 
 	}
 
@@ -372,7 +372,7 @@ func (c *RemoteClient) Unlock(id string) error {
 	// checking the ID from the info field first.
 	lockInfo, err := c.getLockInfo()
 	if err != nil {
-		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %s", err)
+		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %w", err)
 		return lockErr
 	}
 	lockErr.Info = lockInfo
@@ -421,5 +421,5 @@ The referenced S3 bucket must have been previously created. If the S3 bucket
 was created within the last minute, please wait for a minute or two and try
 again.
 
-Error: %s
+Error: %w
 `

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -655,7 +655,7 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 
 	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
 	if err != nil && err != tfe.ErrResourceNotFound {
-		return nil, fmt.Errorf("Failed to retrieve workspace %s: %v", name, err)
+		return nil, fmt.Errorf("Failed to retrieve workspace %s: %w", name, err)
 	}
 
 	if err == tfe.ErrResourceNotFound {
@@ -671,7 +671,7 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 
 		workspace, err = b.client.Workspaces.Create(context.Background(), b.organization, options)
 		if err != nil {
-			return nil, fmt.Errorf("Error creating workspace %s: %v", name, err)
+			return nil, fmt.Errorf("Error creating workspace %s: %w", name, err)
 		}
 	}
 
@@ -734,7 +734,7 @@ func (b *Remote) fetchWorkspace(ctx context.Context, organization string, name s
 			)
 		default:
 			err := fmt.Errorf(
-				"the configured \"remote\" backend encountered an unexpected error:\n\n%s",
+				"the configured \"remote\" backend encountered an unexpected error:\n\n%w",
 				err,
 			)
 			return nil, err

--- a/internal/backend/remote/backend_common.go
+++ b/internal/backend/remote/backend_common.go
@@ -438,9 +438,7 @@ func (b *Remote) checkPolicy(stopCtx, cancelCtx context.Context, op *backend.Ope
 				}
 				err = b.confirm(stopCtx, op, opts, r, "override")
 				if err != nil && err != errRunOverridden {
-					return fmt.Errorf(
-						fmt.Sprintf("Failed to override: %s\n%s\n", err.Error(), runUrl),
-					)
+					return fmt.Errorf("Failed to override: %w\n%s\n", err, runUrl)
 				}
 
 				if err != errRunOverridden {
@@ -530,7 +528,7 @@ func (b *Remote) confirm(stopCtx context.Context, op *backend.Operation, opts *o
 	result <- func() error {
 		v, err := op.UIIn.Input(doneCtx, opts)
 		if err != nil && err != context.Canceled && stopCtx.Err() != context.Canceled {
-			return fmt.Errorf("Error asking %s: %v", opts.Id, err)
+			return fmt.Errorf("Error asking %s: %w", opts.Id, err)
 		}
 
 		// We return the error of our parent channel as we don't


### PR DESCRIPTION
This wraps formatted errors in `internal/backend` using the `%w` directive instead of `%v` or `%s`. I left the tests alone.

part of #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.