### PR TITLE
don't indent JSON in state files

### DIFF
--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -421,7 +421,7 @@ func writeStateV4(file *File, w io.Writer) tfdiags.Diagnostics {
 
 	sV4.normalize()
 
-	src, err := json.MarshalIndent(sV4, "", "  ")
+	src, err := json.Marshal(sV4)
 	if err != nil {
 		// Shouldn't happen if we do our conversion to *stateV4 correctly above.
 		diags = diags.Append(tfdiags.Sourceless(


### PR DESCRIPTION
My colleague @jonjohnsonjr has been doing quite a lot of profiling of `terraform`, and has found some possible areas where time is being wasted unnecessarily.

The following flamegraph shows where time is spent running `terraform apply` on an admittedly pretty pathologically large TF graph (aren't they all 🤷). It shows TF state being marshalled to JSON 4 times, taking up about 1/2 of the total time. This is done so that the previous/new state can be diffed, to determine if any changes actually need to be made.

Roughly half of each of those JSON marshallings is `appendIndent`, which is only called with `json.MarshalIndent`.

<img width="1419" alt="Screenshot 2023-09-13 at 1 43 20 PM" src="https://github.com/opentffoundation/opentf/assets/210737/7202e9f8-1972-4521-b2b0-4dcb9b35521d">

The theory is that dropping indentation would cut this 22s apply down to about 17s.

I am not a deep enough TF expert to know what other implications this change might have. Based on a brief look around, I don't believe it would have any impact on state diffing, since both sides of the diff go through this same code path to accomplish the diff (and so would both be unmarshalled or not).

There might be other cases where state is expected/required to be marshalled for some reason; AFAIK, no human is expected to read that directly, but maybe something somewhere cares about there being newlines and spaces. If nothing else I'd love to learn through this process what that might be, if this change isn't safe after all.