### PR TITLE
Add pending-decision label to newly created issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,7 @@
 
 name: Bug Report
 description: Let us know about an unexpected error, a crash, or an incorrect behavior.
-labels: ["bug", "new"]
+labels: ["bug", "pending-decision"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,7 @@
 
 name: Feature Request
 description: Suggest a new feature or other enhancement.
-labels: ["enhancement", "new"]
+labels: ["enhancement", "pending-decision"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -2,7 +2,7 @@
 
 name: Submit RFC
 description: Submit a highly-structured change request for public discussion.
-labels: ["rfc", "new"]
+labels: ["rfc", "pending-decision"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Implements #403 for our issue templates.