### PR TITLE
Fix slack invite with a link that never expires.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - Manifesto: https://opentf.org
 - About the OpenTF fork: https://opentf.org/fork
-- [Join our Slack community!](https://join.slack.com/t/opentfcommunity/shared_invite/zt-232puvqp1-G6gbcbIr6QJBjabdfOC3xw)
+- [Join our Slack community!](https://join.slack.com/t/opentfcommunity/shared_invite/zt-237chyryd-mFULiefrbYGMYQoG72BUpQ)
 
 <img alt="OpenTF" src="https://raw.githubusercontent.com/opentffoundation/brand-artifacts/main/full/transparent/SVG/on-light.svg" width="600px">
 


### PR DESCRIPTION
fixes #392 