### PR TITLE
internal/builtin internal/cloud internal/command Wrap Errors

### DIFF
--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -179,7 +179,7 @@ func copyFiles(ctx context.Context, comm communicator.Communicator, src, dst str
 	// If we're uploading a directory, short circuit and do that
 	if info.IsDir() {
 		if err := comm.UploadDir(dst, src); err != nil {
-			return fmt.Errorf("Upload failed: %v", err)
+			return fmt.Errorf("Upload failed: %w", err)
 		}
 		return nil
 	}
@@ -193,7 +193,7 @@ func copyFiles(ctx context.Context, comm communicator.Communicator, src, dst str
 
 	err = comm.Upload(dst, f)
 	if err != nil {
-		return fmt.Errorf("Upload failed: %v", err)
+		return fmt.Errorf("Upload failed: %w", err)
 	}
 
 	return err

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -218,7 +218,7 @@ func collectScripts(v cty.Value) ([]io.ReadCloser, error) {
 			for _, fh := range fhs {
 				fh.Close()
 			}
-			return nil, fmt.Errorf("Failed to open script '%s': %v", s, err)
+			return nil, fmt.Errorf("Failed to open script '%s': %w", s, err)
 		}
 		fhs = append(fhs, fh)
 	}
@@ -260,7 +260,7 @@ func runScripts(ctx context.Context, o provisioners.UIOutput, comm communicator.
 		remotePath := comm.ScriptPath()
 
 		if err := comm.UploadScript(remotePath, script); err != nil {
-			return fmt.Errorf("Failed to upload script: %v", err)
+			return fmt.Errorf("Failed to upload script: %w", err)
 		}
 
 		cmd = &remote.Cmd{
@@ -269,7 +269,7 @@ func runScripts(ctx context.Context, o provisioners.UIOutput, comm communicator.
 			Stderr:  errW,
 		}
 		if err := comm.Start(cmd); err != nil {
-			return fmt.Errorf("Error starting script: %v", err)
+			return fmt.Errorf("Error starting script: %w", err)
 		}
 
 		if err := cmd.Wait(); err != nil {

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -556,7 +556,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 		}
 		projects, err := b.client.Projects.List(context.Background(), b.organization, listOpts)
 		if err != nil && err != tfe.ErrResourceNotFound {
-			return nil, fmt.Errorf("failed to retrieve project %s: %v", listOpts.Name, err)
+			return nil, fmt.Errorf("failed to retrieve project %s: %w", listOpts.Name, err)
 		}
 		for _, p := range projects.Items {
 			if p.Name == b.WorkspaceMapping.Project {
@@ -607,7 +607,7 @@ func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to retrieve workspace %s: %v", name, err)
+		return fmt.Errorf("failed to retrieve workspace %s: %w", name, err)
 	}
 
 	// Configure the remote workspace name.
@@ -629,7 +629,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 
 	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
 	if err != nil && err != tfe.ErrResourceNotFound {
-		return nil, fmt.Errorf("Failed to retrieve workspace %s: %v", name, err)
+		return nil, fmt.Errorf("Failed to retrieve workspace %s: %w", name, err)
 	}
 	if workspace != nil {
 		remoteTFVersion = workspace.TerraformVersion
@@ -683,7 +683,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 				log.Printf("[TRACE] cloud: Creating cloud backend project %s/%s", b.organization, b.WorkspaceMapping.Project)
 				project, err := b.client.Projects.Create(context.Background(), b.organization, createOpts)
 				if err != nil && err != tfe.ErrResourceNotFound {
-					return nil, fmt.Errorf("failed to create project %s: %v", b.WorkspaceMapping.Project, err)
+					return nil, fmt.Errorf("failed to create project %s: %w", b.WorkspaceMapping.Project, err)
 				}
 				configuredProject = project
 				workspaceCreateOptions.Project = configuredProject
@@ -694,7 +694,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 		log.Printf("[TRACE] cloud: Creating cloud backend workspace %s/%s", b.organization, name)
 		workspace, err = b.client.Workspaces.Create(context.Background(), b.organization, workspaceCreateOptions)
 		if err != nil {
-			return nil, fmt.Errorf("error creating workspace %s: %v", name, err)
+			return nil, fmt.Errorf("error creating workspace %s: %w", name, err)
 		}
 
 		remoteTFVersion = workspace.TerraformVersion
@@ -729,7 +729,7 @@ func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 		log.Printf("[TRACE] cloud: Adding tags for cloud backend workspace %s/%s", b.organization, name)
 		err = b.client.Workspaces.AddTags(context.Background(), workspace.ID, options)
 		if err != nil {
-			return nil, fmt.Errorf("Error updating workspace %s: %v", name, err)
+			return nil, fmt.Errorf("Error updating workspace %s: %w", name, err)
 		}
 	}
 
@@ -1120,7 +1120,7 @@ func (b *Cloud) fetchWorkspace(ctx context.Context, organization string, workspa
 			)
 		default:
 			err := fmt.Errorf(
-				"Terraform Cloud returned an unexpected error:\n\n%s",
+				"Terraform Cloud returned an unexpected error:\n\n%w",
 				err,
 			)
 			return nil, err

--- a/internal/cloud/backend_common.go
+++ b/internal/cloud/backend_common.go
@@ -502,7 +502,7 @@ func (b *Cloud) confirm(stopCtx context.Context, op *backend.Operation, opts *op
 	result <- func() error {
 		v, err := op.UIIn.Input(doneCtx, opts)
 		if err != nil && err != context.Canceled && stopCtx.Err() != context.Canceled {
-			return fmt.Errorf("Error asking %s: %v", opts.Id, err)
+			return fmt.Errorf("Error asking %s: %w", opts.Id, err)
 		}
 
 		// We return the error of our parent channel as we don't

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -399,7 +399,7 @@ func (b *Cloud) AssertImportCompatible(config *configs.Config) error {
 		// First, check the remote API version is high enough.
 		currentAPIVersion, err := version.NewVersion(b.client.RemoteAPIVersion())
 		if err != nil {
-			return fmt.Errorf("Error parsing remote API version. To proceed, please remove any import blocks from your config. Please report the following error to the OpenTF team: %s", err)
+			return fmt.Errorf("Error parsing remote API version. To proceed, please remove any import blocks from your config. Please report the following error to the OpenTF team: %w", err)
 		}
 		desiredAPIVersion, _ := version.NewVersion("2.6")
 		if currentAPIVersion.LessThan(desiredAPIVersion) {
@@ -413,7 +413,7 @@ func (b *Cloud) AssertImportCompatible(config *configs.Config) error {
 		}
 		currentAgentVersion, err := version.NewVersion(agentEnv)
 		if err != nil {
-			return fmt.Errorf("Error parsing TFC agent version. To proceed, please remove any import blocks from your config. Please report the following error to the OpenTF team: %s", err)
+			return fmt.Errorf("Error parsing TFC agent version. To proceed, please remove any import blocks from your config. Please report the following error to the OpenTF team: %w", err)
 		}
 		desiredAgentVersion, _ := version.NewVersion("1.10")
 		if currentAgentVersion.LessThan(desiredAgentVersion) {

--- a/internal/cloud/backend_taskStages.go
+++ b/internal/cloud/backend_taskStages.go
@@ -178,7 +178,7 @@ func (b *Cloud) processStageOverrides(context *IntegrationContext, output Integr
 	err := b.confirm(context.StopContext, context.Op, opts, context.Run, "override")
 	if err != nil && err != errRunOverridden {
 		return false, fmt.Errorf(
-			fmt.Sprintf("Failed to override: %s\n%s\n", err.Error(), runUrl),
+			fmt.Sprintf("Failed to override: %s\n%s\n", err, runUrl),
 		)
 	}
 

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -179,7 +179,7 @@ func (s *State) PersistState(schemas *opentf.Schemas) error {
 		// that we ought to be updating.
 		err := s.refreshState()
 		if err != nil {
-			return fmt.Errorf("failed checking for existing remote state: %s", err)
+			return fmt.Errorf("failed checking for existing remote state: %w", err)
 		}
 		log.Printf("[DEBUG] cloud/state: after refresh, state read serial is: %d; serial is: %d", s.readSerial, s.serial)
 		log.Printf("[DEBUG] cloud/state: after refresh, state read lineage is: %s; lineage is: %s", s.readLineage, s.lineage)
@@ -187,7 +187,7 @@ func (s *State) PersistState(schemas *opentf.Schemas) error {
 		if s.lineage == "" { // indicates that no state snapshot is present yet
 			lineage, err := uuid.GenerateUUID()
 			if err != nil {
-				return fmt.Errorf("failed to generate initial lineage: %v", err)
+				return fmt.Errorf("failed to generate initial lineage: %w", err)
 			}
 			s.lineage = lineage
 			s.serial++
@@ -343,7 +343,7 @@ func (s *State) Lock(info *statemgr.LockInfo) (string, error) {
 	if err != nil {
 		if err == tfe.ErrWorkspaceLocked {
 			lockErr.Info = info
-			err = fmt.Errorf("%s (lock ID: \"%s/%s\")", err, s.organization, s.workspace.Name)
+			err = fmt.Errorf("%w (lock ID: \"%s/%s\")", err, s.organization, s.workspace.Name)
 		}
 		lockErr.Err = err
 		return "", lockErr
@@ -408,12 +408,12 @@ func (s *State) getStatePayload() (*remote.Payload, error) {
 			// If no state exists, then return nil.
 			return nil, nil
 		}
-		return nil, fmt.Errorf("error retrieving state: %v", err)
+		return nil, fmt.Errorf("error retrieving state: %w", err)
 	}
 
 	state, err := s.tfeClient.StateVersions.Download(ctx, sv.DownloadURL)
 	if err != nil {
-		return nil, fmt.Errorf("error downloading state: %v", err)
+		return nil, fmt.Errorf("error downloading state: %w", err)
 	}
 
 	// If the state is empty, then return nil.
@@ -502,7 +502,7 @@ func (s *State) Delete(force bool) error {
 	}
 
 	if err != nil && err != tfe.ErrResourceNotFound {
-		return fmt.Errorf("error deleting workspace %s: %v", s.workspace.Name, err)
+		return fmt.Errorf("error deleting workspace %s: %w", s.workspace.Name, err)
 	}
 
 	return nil

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -278,7 +278,7 @@ func (c *ApplyCommand) OperationRequest(
 	var err error
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags
 	}
 

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -153,20 +153,20 @@ func loadConfigFile(path string) (*Config, tfdiags.Diagnostics) {
 	// Read the HCL file and prepare for parsing
 	d, err := os.ReadFile(path)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Error reading %s: %s", path, err))
+		diags = diags.Append(fmt.Errorf("Error reading %s: %w", path, err))
 		return result, diags
 	}
 
 	// Parse it
 	obj, err := hcl.Parse(string(d))
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Error parsing %s: %s", path, err))
+		diags = diags.Append(fmt.Errorf("Error parsing %s: %w", path, err))
 		return result, diags
 	}
 
 	// Build up the result
 	if err := hcl.DecodeObject(&result, obj); err != nil {
-		diags = diags.Append(fmt.Errorf("Error parsing %s: %s", path, err))
+		diags = diags.Append(fmt.Errorf("Error parsing %s: %w", path, err))
 		return result, diags
 	}
 
@@ -198,7 +198,7 @@ func loadConfigDir(path string) (*Config, tfdiags.Diagnostics) {
 
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Error reading %s: %s", path, err))
+		diags = diags.Append(fmt.Errorf("Error reading %s: %w", path, err))
 		return result, diags
 	}
 
@@ -291,7 +291,7 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 		_, err := svchost.ForComparison(givenHost)
 		if err != nil {
 			diags = diags.Append(
-				fmt.Errorf("The host %q block has an invalid hostname: %s", givenHost, err),
+				fmt.Errorf("The host %q block has an invalid hostname: %w", givenHost, err),
 			)
 		}
 	}
@@ -301,7 +301,7 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 		_, err := svchost.ForComparison(givenHost)
 		if err != nil {
 			diags = diags.Append(
-				fmt.Errorf("The credentials %q block has an invalid hostname: %s", givenHost, err),
+				fmt.Errorf("The credentials %q block has an invalid hostname: %w", givenHost, err),
 			)
 		}
 	}
@@ -324,7 +324,7 @@ func (c *Config) Validate() tfdiags.Diagnostics {
 		_, err := os.Stat(c.PluginCacheDir)
 		if err != nil {
 			diags = diags.Append(
-				fmt.Errorf("The specified plugin cache dir %s cannot be opened: %s", c.PluginCacheDir, err),
+				fmt.Errorf("The specified plugin cache dir %s cannot be opened: %w", c.PluginCacheDir, err),
 			)
 		}
 	}

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -42,7 +42,7 @@ func (c *Config) CredentialsSource(helperPlugins pluginDiscovery.PluginMetaSet) 
 	if err != nil {
 		// If we managed to load a Config object at all then we would already
 		// have located this file, so this error is very unlikely.
-		return nil, fmt.Errorf("can't locate credentials file: %s", err)
+		return nil, fmt.Errorf("can't locate credentials file: %w", err)
 	}
 
 	var helper svcauth.CredentialsSource
@@ -325,12 +325,12 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 
 	filename, err := s.CredentialsFilePath()
 	if err != nil {
-		return fmt.Errorf("unable to determine credentials file path: %s", err)
+		return fmt.Errorf("unable to determine credentials file path: %w", err)
 	}
 
 	oldSrc, err := os.ReadFile(filename)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("cannot read %s: %s", filename, err)
+		return fmt.Errorf("cannot read %s: %w", filename, err)
 	}
 
 	var raw map[string]interface{}
@@ -342,7 +342,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		dec.UseNumber()
 		err = dec.Decode(&raw)
 		if err != nil {
-			return fmt.Errorf("cannot read %s: %s", filename, err)
+			return fmt.Errorf("cannot read %s: %w", filename, err)
 		}
 	} else {
 		raw = make(map[string]interface{})
@@ -383,7 +383,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 
 	newSrc, err := json.MarshalIndent(raw, "", "  ")
 	if err != nil {
-		return fmt.Errorf("cannot serialize updated credentials file: %s", err)
+		return fmt.Errorf("cannot serialize updated credentials file: %w", err)
 	}
 
 	// Now we'll write our new content over the top of the existing file.
@@ -397,7 +397,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		dir, file := filepath.Split(filename)
 		f, err := os.CreateTemp(dir, file)
 		if err != nil {
-			return fmt.Errorf("cannot create temporary file to update credentials: %s", err)
+			return fmt.Errorf("cannot create temporary file to update credentials: %w", err)
 		}
 		tmpName := f.Name()
 		moved := false
@@ -415,7 +415,7 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		_, err = f.Write(newSrc)
 		f.Close()
 		if err != nil {
-			return fmt.Errorf("cannot write to temporary file %s: %s", tmpName, err)
+			return fmt.Errorf("cannot write to temporary file %s: %w", tmpName, err)
 		}
 
 		// Temporary file now replaces the original file, as atomically as
@@ -423,14 +423,14 @@ func (s *CredentialsSource) updateLocalHostCredentials(host svchost.Hostname, ne
 		// containing only a partial JSON object.)
 		err = replacefile.AtomicRename(tmpName, filename)
 		if err != nil {
-			return fmt.Errorf("failed to replace %s with temporary file %s: %s", filename, tmpName, err)
+			return fmt.Errorf("failed to replace %s with temporary file %s: %w", filename, tmpName, err)
 		}
 
 		// Credentials file should be readable only by its owner. (This may
 		// not be effective on all platforms, but should at least work on
 		// Unix-like targets and should be harmless elsewhere.)
 		if err := os.Chmod(filename, 0600); err != nil {
-			return fmt.Errorf("cannot set mode for credentials file %s: %s", filename, err)
+			return fmt.Errorf("cannot set mode for credentials file %s: %w", filename, err)
 		}
 
 		moved = true

--- a/internal/command/clistate/local_state.go
+++ b/internal/command/clistate/local_state.go
@@ -297,7 +297,7 @@ func (s *LocalState) lockInfo() (*statemgr.LockInfo, error) {
 	info := statemgr.LockInfo{}
 	err = json.Unmarshal(infoData, &info)
 	if err != nil {
-		return nil, fmt.Errorf("state file %q locked, but could not unmarshal lock info: %s", s.Path, err)
+		return nil, fmt.Errorf("state file %q locked, but could not unmarshal lock info: %w", s.Path, err)
 	}
 	return &info, nil
 }
@@ -310,7 +310,7 @@ func (s *LocalState) writeLockInfo(info *statemgr.LockInfo) error {
 
 	err := os.WriteFile(path, info.Marshal(), 0600)
 	if err != nil {
-		return fmt.Errorf("could not write lock info for %q: %s", s.Path, err)
+		return fmt.Errorf("could not write lock info for %q: %w", s.Path, err)
 	}
 	return nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -67,7 +67,7 @@ func ModulePath(args []string) (string, error) {
 
 	path, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("Error getting pwd: %s", err)
+		return "", fmt.Errorf("Error getting pwd: %w", err)
 	}
 
 	return path, nil

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -208,7 +208,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, isStdout
 		if c.diff {
 			diff, err := bytesDiff(src, result, path)
 			if err != nil {
-				diags = diags.Append(fmt.Errorf("Failed to generate diff for %s: %s", path, err))
+				diags = diags.Append(fmt.Errorf("Failed to generate diff for %s: %w", path, err))
 				return diags
 			}
 			w.Write(diff)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -163,7 +163,7 @@ func (c *InitCommand) Run(args []string) int {
 	// the backend with an empty directory.
 	empty, err := configs.IsEmptyDir(path)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Error checking configuration: %s", err))
+		diags = diags.Append(fmt.Errorf("Error checking configuration: %w", err))
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -227,13 +227,13 @@ func MarshalForLog(
 
 	err := output.marshalPlanVariables(p.VariableValues, config.Module.Variables)
 	if err != nil {
-		return nil, fmt.Errorf("error in marshalPlanVariables: %s", err)
+		return nil, fmt.Errorf("error in marshalPlanVariables: %w", err)
 	}
 
 	// output.PlannedValues
 	err = output.marshalPlannedValues(p.Changes, schemas)
 	if err != nil {
-		return nil, fmt.Errorf("error in marshalPlannedValues: %s", err)
+		return nil, fmt.Errorf("error in marshalPlannedValues: %w", err)
 	}
 
 	// output.ResourceDrift
@@ -254,25 +254,25 @@ func MarshalForLog(
 		}
 		output.ResourceDrift, err = MarshalResourceChanges(driftedResources, schemas)
 		if err != nil {
-			return nil, fmt.Errorf("error in marshaling resource drift: %s", err)
+			return nil, fmt.Errorf("error in marshaling resource drift: %w", err)
 		}
 	}
 
 	if err := output.marshalRelevantAttrs(p); err != nil {
-		return nil, fmt.Errorf("error marshaling relevant attributes for external changes: %s", err)
+		return nil, fmt.Errorf("error marshaling relevant attributes for external changes: %w", err)
 	}
 
 	// output.ResourceChanges
 	if p.Changes != nil {
 		output.ResourceChanges, err = MarshalResourceChanges(p.Changes.Resources, schemas)
 		if err != nil {
-			return nil, fmt.Errorf("error in marshaling resource changes: %s", err)
+			return nil, fmt.Errorf("error in marshaling resource changes: %w", err)
 		}
 	}
 
 	// output.OutputChanges
 	if output.OutputChanges, err = MarshalOutputChanges(p.Changes); err != nil {
-		return nil, fmt.Errorf("error in marshaling output changes: %s", err)
+		return nil, fmt.Errorf("error in marshaling output changes: %w", err)
 	}
 
 	// output.Checks
@@ -284,14 +284,14 @@ func MarshalForLog(
 	if sf != nil && !sf.State.Empty() {
 		output.PriorState, err = jsonstate.Marshal(sf, schemas)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling prior state: %s", err)
+			return nil, fmt.Errorf("error marshaling prior state: %w", err)
 		}
 	}
 
 	// output.Config
 	output.Config, err = jsonconfig.Marshal(config, schemas)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling config: %s", err)
+		return nil, fmt.Errorf("error marshaling config: %w", err)
 	}
 
 	return output, nil
@@ -913,13 +913,13 @@ func encodePath(path cty.Path) (json.RawMessage, error) {
 		case cty.IndexStep:
 			key, err := ctyjson.Marshal(s.Key, s.Key.Type())
 			if err != nil {
-				return nil, fmt.Errorf("Failed to marshal index step key %#v: %s", s.Key, err)
+				return nil, fmt.Errorf("Failed to marshal index step key %#v: %w", s.Key, err)
 			}
 			steps = append(steps, key)
 		case cty.GetAttrStep:
 			name, err := json.Marshal(s.Name)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to marshal get attr step name %#v: %s", s.Name, err)
+				return nil, fmt.Errorf("Failed to marshal get attr step name %#v: %w", s.Name, err)
 			}
 			steps = append(steps, name)
 		default:

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -545,7 +545,7 @@ func (c *LoginCommand) interactiveGetTokenByPassword(hostname svchost.Hostname, 
 		Query: fmt.Sprintf("Username for %s:", hostname.ForDisplay()),
 	})
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to request username: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to request username: %w", err))
 		return nil, diags
 	}
 	password, err := c.UIInput().Input(context.Background(), &opentf.InputOpts{
@@ -554,7 +554,7 @@ func (c *LoginCommand) interactiveGetTokenByPassword(hostname svchost.Hostname, 
 		Secret: true,
 	})
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to request password: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to request password: %w", err))
 		return nil, diags
 	}
 
@@ -637,7 +637,7 @@ func (c *LoginCommand) interactiveGetTokenByUI(hostname svchost.Hostname, credsC
 		Secret: true,
 	})
 	if err != nil {
-		diags := diags.Append(fmt.Errorf("Failed to retrieve token: %s", err))
+		diags := diags.Append(fmt.Errorf("Failed to retrieve token: %w", err))
 		return "", diags
 	}
 
@@ -650,15 +650,15 @@ func (c *LoginCommand) interactiveGetTokenByUI(hostname svchost.Hostname, credsC
 	}
 	client, err := tfe.NewClient(cfg)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to create API client: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to create API client: %w", err))
 		return "", diags
 	}
 	user, err := client.Users.ReadCurrent(context.Background())
 	if err == tfe.ErrUnauthorized {
-		diags = diags.Append(fmt.Errorf("Token is invalid: %s", err))
+		diags = diags.Append(fmt.Errorf("Token is invalid: %w", err))
 		return "", diags
 	} else if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to retrieve user account details: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to retrieve user account details: %w", err))
 		return "", diags
 	}
 	c.Ui.Output(fmt.Sprintf(c.Colorize().Color("\nRetrieved token for user [bold]%s[reset]\n"), user.Username))

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -477,7 +477,7 @@ func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*back
 
 	op, err := b.Operation(context.Background(), opReq)
 	if err != nil {
-		return nil, fmt.Errorf("error starting operation: %s", err)
+		return nil, fmt.Errorf("error starting operation: %w", err)
 	}
 
 	// Wait for the operation to complete or an interrupt to occur
@@ -660,7 +660,7 @@ func (m *Meta) confirm(opts *opentf.InputOpts) (bool, error) {
 		v, err := m.UIInput().Input(context.Background(), opts)
 		if err != nil {
 			return false, fmt.Errorf(
-				"Error asking for confirmation: %s", err)
+				"Error asking for confirmation: %w", err)
 		}
 
 		switch strings.ToLower(v) {

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -178,7 +178,7 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 		})
 		if err != nil {
 			return fmt.Errorf(
-				"Error asking for state migration action: %s", err)
+				"Error asking for state migration action: %w", err)
 		}
 	}
 	if !migrate {
@@ -239,7 +239,7 @@ func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 		})
 		if err != nil {
 			return fmt.Errorf(
-				"Error asking for state migration action: %s", err)
+				"Error asking for state migration action: %w", err)
 		}
 	}
 
@@ -302,7 +302,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 			// the named workspace as the new selected workspace.
 			if workspace == backend.DefaultStateName {
 				if err := m.SetWorkspace(opts.destinationWorkspace); err != nil {
-					return nil, fmt.Errorf("Failed to set new workspace: %s", err)
+					return nil, fmt.Errorf("Failed to set new workspace: %w", err)
 				}
 			}
 
@@ -489,7 +489,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 	// Save both to a temporary
 	td, err := os.MkdirTemp("", "terraform")
 	if err != nil {
-		return false, fmt.Errorf("Error creating temporary directory: %s", err)
+		return false, fmt.Errorf("Error creating temporary directory: %w", err)
 	}
 	defer os.RemoveAll(td)
 
@@ -503,10 +503,10 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 	sourcePath := filepath.Join(td, fmt.Sprintf("1-%s.tfstate", opts.SourceType))
 	destinationPath := filepath.Join(td, fmt.Sprintf("2-%s.tfstate", opts.DestinationType))
 	if err := saveHelper(opts.SourceType, sourcePath, source); err != nil {
-		return false, fmt.Errorf("Error saving temporary state: %s", err)
+		return false, fmt.Errorf("Error saving temporary state: %w", err)
 	}
 	if err := saveHelper(opts.DestinationType, destinationPath, destination); err != nil {
-		return false, fmt.Errorf("Error saving temporary state: %s", err)
+		return false, fmt.Errorf("Error saving temporary state: %w", err)
 	}
 
 	// Ask for confirmation
@@ -813,7 +813,7 @@ func (m *Meta) promptSingleToCloudSingleStateMigration(opts *backendMigrateOpts)
 			Description: strings.TrimSpace(tfcInputBackendMigrateStateSingleToCloudSingle),
 		})
 		if err != nil {
-			return false, fmt.Errorf("Error asking for state migration action: %s", err)
+			return false, fmt.Errorf("Error asking for state migration action: %w", err)
 		}
 	}
 
@@ -834,7 +834,7 @@ func (m *Meta) promptRemotePrefixToCloudTagsMigration(opts *backendMigrateOpts) 
 			Description: strings.TrimSpace(tfcInputBackendMigrateRemoteMultiToCloud),
 		})
 		if err != nil {
-			return fmt.Errorf("Error asking for state migration action: %s", err)
+			return fmt.Errorf("Error asking for state migration action: %w", err)
 		}
 	}
 
@@ -863,7 +863,7 @@ func (m *Meta) promptMultiToSingleCloudMigration(opts *backendMigrateOpts) error
 				opts.SourceType, opts.destinationWorkspace),
 		})
 		if err != nil {
-			return fmt.Errorf("Error asking for state migration action: %s", err)
+			return fmt.Errorf("Error asking for state migration action: %w", err)
 		}
 	}
 
@@ -890,7 +890,7 @@ func (m *Meta) promptNewWorkspaceName(destinationType string) (string, error) {
 		Description: strings.TrimSpace(inputBackendNewWorkspaceName),
 	})
 	if err != nil {
-		return "", fmt.Errorf("Error asking for new state name: %s", err)
+		return "", fmt.Errorf("Error asking for new state name: %w", err)
 	}
 
 	return name, nil
@@ -905,7 +905,7 @@ func (m *Meta) promptMultiStateMigrationPattern(sourceType string) (string, erro
 		Description: fmt.Sprintf(strings.TrimSpace(tfcInputBackendMigrateMultiToMulti), sourceType),
 	})
 	if err != nil {
-		return "", fmt.Errorf("Error asking for state migration action: %s", err)
+		return "", fmt.Errorf("Error asking for state migration action: %w", err)
 	}
 	if renameWorkspaces != "2" && renameWorkspaces != "1" {
 		return "", fmt.Errorf("Please select 1 or 2 as part of this option.")
@@ -923,7 +923,7 @@ func (m *Meta) promptMultiStateMigrationPattern(sourceType string) (string, erro
 		Description: strings.TrimSpace(tfcInputBackendMigrateMultiToMultiPattern),
 	})
 	if err != nil {
-		return "", fmt.Errorf("Error asking for state migration action: %s", err)
+		return "", fmt.Errorf("Error asking for state migration action: %w", err)
 	}
 	if !strings.Contains(pattern, "*") {
 		return "", fmt.Errorf("The pattern must have an '*'")
@@ -938,7 +938,7 @@ func (m *Meta) promptMultiStateMigrationPattern(sourceType string) (string, erro
 
 const errMigrateLoadStates = `
 Error inspecting states in the %q backend:
-    %s
+    %w
 
 Prior to changing backends, OpenTF inspects the source and destination
 states to determine what kind of migration steps need to be taken, if any.
@@ -947,10 +947,9 @@ destination remain unmodified. Please resolve the above error and try again.
 `
 
 const errMigrateSingleLoadDefault = `
-Error loading state:
-    %[2]s
+Error loading default state from the %q backend:
+    %w
 
-OpenTF failed to load the default state from the %[1]q backend.
 State migration cannot occur unless the state can be loaded. Backend
 modification and state migration has been aborted. The state in both the
 source and the destination remain unmodified. Please resolve the
@@ -960,7 +959,7 @@ above error and try again.
 const errMigrateMulti = `
 Error migrating the workspace %q from the previous %q backend
 to the newly configured %q backend:
-    %s
+    %w
 
 OpenTF copies workspaces in alphabetical order. Any workspaces
 alphabetically earlier than this one have been copied. Any workspaces
@@ -974,7 +973,7 @@ This will attempt to copy (with permission) all workspaces again.
 const errBackendStateCopy = `
 Error copying state from the previous %q backend to the newly configured
 %q backend:
-    %s
+    %w
 
 The state in the previous backend remains intact and unmodified. Please resolve
 the error above and try again.

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -288,7 +288,7 @@ func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block) (cty.
 				Description: attrS.Description,
 			})
 			if err != nil {
-				return cty.UnknownVal(schema.ImpliedType()), fmt.Errorf("%s: %s", name, err)
+				return cty.UnknownVal(schema.ImpliedType()), fmt.Errorf("%s: %w", name, err)
 			}
 
 			val := cty.StringVal(strVal)

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -231,7 +231,7 @@ func (m *Meta) providerDevOverrideRuntimeWarnings() tfdiags.Diagnostics {
 func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error) {
 	locks, diags := m.lockedDependencies()
 	if diags.HasErrors() {
-		return nil, fmt.Errorf("failed to read dependency lock file: %s", diags.Err())
+		return nil, fmt.Errorf("failed to read dependency lock file: %w", diags.Err())
 	}
 
 	// We'll always run through all of our providers, even if one of them
@@ -306,7 +306,7 @@ func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error)
 			matched, err := cached.MatchesAnyHash(allowedHashes)
 			if err != nil {
 				reportError(fmt.Errorf(
-					"failed to verify checksum of %s %s package cached in in %s: %s",
+					"failed to verify checksum of %s %s package cached in in %s: %w",
 					provider, version, cacheDir.BasePath(), err,
 				))
 				continue


### PR DESCRIPTION
This wraps formatted errors in internal/builtin, internal/cloud, and internal/command using the %w directive instead of %v or %s. I left the tests alone.

part of #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.