### PR TITLE
Multi Package Wrap Errors

### DIFF
--- a/internal/communicator/communicator.go
+++ b/internal/communicator/communicator.go
@@ -161,9 +161,9 @@ func Retry(ctx context.Context, f func() error) error {
 	// Check if we have a context error to check if we're interrupted or timeout
 	switch ctx.Err() {
 	case context.Canceled:
-		return fmt.Errorf("interrupted - last error: %v", lastErr)
+		return fmt.Errorf("interrupted - last error: %w", lastErr)
 	case context.DeadlineExceeded:
-		return fmt.Errorf("timeout - last error: %v", lastErr)
+		return fmt.Errorf("timeout - last error: %w", lastErr)
 	}
 
 	if lastErr != nil {

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -447,7 +447,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	reader := bufio.NewReader(input)
 	prefix, err := reader.Peek(2)
 	if err != nil {
-		return fmt.Errorf("Error reading script: %s", err)
+		return fmt.Errorf("Error reading script: %w", err)
 	}
 	var script bytes.Buffer
 
@@ -634,7 +634,7 @@ func checkSCPStatus(r *bufio.Reader) error {
 		// Treat any non-zero (really 1 and 2) as fatal errors
 		message, _, err := r.ReadLine()
 		if err != nil {
-			return fmt.Errorf("Error reading error message: %s", err)
+			return fmt.Errorf("Error reading error message: %w", err)
 		}
 
 		return errors.New(string(message))
@@ -655,7 +655,7 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, size
 		// so that we can determine the length, since SCP is length-prefixed.
 		tf, err := os.CreateTemp("", "terraform-upload")
 		if err != nil {
-			return fmt.Errorf("Error creating temporary file for upload: %s", err)
+			return fmt.Errorf("Error creating temporary file for upload: %w", err)
 		}
 		defer os.Remove(tf.Name())
 		defer tf.Close()
@@ -668,17 +668,17 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, size
 		// Sync the file so that the contents are definitely on disk, then
 		// read the length of it.
 		if err := tf.Sync(); err != nil {
-			return fmt.Errorf("Error creating temporary file for upload: %s", err)
+			return fmt.Errorf("Error creating temporary file for upload: %w", err)
 		}
 
 		// Seek the file to the beginning so we can re-read all of it
 		if _, err := tf.Seek(0, 0); err != nil {
-			return fmt.Errorf("Error creating temporary file for upload: %s", err)
+			return fmt.Errorf("Error creating temporary file for upload: %w", err)
 		}
 
 		fi, err := tf.Stat()
 		if err != nil {
-			return fmt.Errorf("Error creating temporary file for upload: %s", err)
+			return fmt.Errorf("Error creating temporary file for upload: %w", err)
 		}
 
 		src = tf
@@ -842,13 +842,13 @@ func BastionConnectFunc(
 			pConn, err = newHttpProxyConn(p, bAddr)
 
 			if err != nil {
-				return nil, fmt.Errorf("Error connecting to proxy: %s", err)
+				return nil, fmt.Errorf("Error connecting to proxy: %w", err)
 			}
 
 			bConn, bChans, bReq, err = ssh.NewClientConn(pConn, bAddr, bConf)
 
 			if err != nil {
-				return nil, fmt.Errorf("Error creating new client connection via proxy: %s", err)
+				return nil, fmt.Errorf("Error creating new client connection via proxy: %w", err)
 			}
 
 			bastion = ssh.NewClient(bConn, bChans, bReq)
@@ -857,7 +857,7 @@ func BastionConnectFunc(
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("Error connecting to bastion: %s", err)
+			return nil, fmt.Errorf("Error connecting to bastion: %w", err)
 		}
 
 		log.Printf("[DEBUG] Connecting via bastion (%s) to host: %s", bAddr, addr)

--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -335,7 +335,7 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 		// file to create the HostKeyCallback.
 		tf, err := os.CreateTemp("", "tf-known_hosts")
 		if err != nil {
-			return nil, fmt.Errorf("failed to create temp known_hosts file: %s", err)
+			return nil, fmt.Errorf("failed to create temp known_hosts file: %w", err)
 		}
 		defer tf.Close()
 		defer os.RemoveAll(tf.Name())
@@ -344,7 +344,7 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 		// use it as a direct match if the remote host doesn't return a
 		// certificate.
 		if _, err := tf.WriteString(fmt.Sprintf("@cert-authority %s %s\n", opts.host, opts.hostKey)); err != nil {
-			return nil, fmt.Errorf("failed to write temp known_hosts file: %s", err)
+			return nil, fmt.Errorf("failed to write temp known_hosts file: %w", err)
 		}
 		tf.Sync()
 
@@ -396,22 +396,22 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, error) {
 	rawPk, err := ssh.ParseRawPrivateKey([]byte(pk))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key %q: %s", pk, err)
+		return nil, fmt.Errorf("failed to parse private key %q: %w", pk, err)
 	}
 
 	pcert, _, _, _, err := ssh.ParseAuthorizedKey([]byte(certificate))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse certificate %q: %s", certificate, err)
+		return nil, fmt.Errorf("failed to parse certificate %q: %w", certificate, err)
 	}
 
 	usigner, err := ssh.NewSignerFromKey(rawPk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create signer from raw private key %q: %s", rawPk, err)
+		return nil, fmt.Errorf("failed to create signer from raw private key %q: %w", rawPk, err)
 	}
 
 	ucertSigner, err := ssh.NewCertSigner(pcert.(*ssh.Certificate), usigner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cert signer %q: %s", usigner, err)
+		return nil, fmt.Errorf("failed to create cert signer %q: %w", usigner, err)
 	}
 
 	return ssh.PublicKeys(ucertSigner), nil
@@ -432,7 +432,7 @@ func readPrivateKey(pk string) (ssh.AuthMethod, error) {
 
 	signer, err := ssh.ParsePrivateKey([]byte(pk))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse ssh private key: %s", err)
+		return nil, fmt.Errorf("Failed to parse ssh private key: %w", err)
 	}
 
 	return ssh.PublicKeys(signer), nil

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -68,7 +68,7 @@ func NewLoader(config *Config) (*Loader, error) {
 
 	err := ret.modules.readModuleManifestSnapshot()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read module manifest: %s", err)
+		return nil, fmt.Errorf("failed to read module manifest: %w", err)
 	}
 
 	return ret, nil

--- a/internal/configs/hcl2shim/flatmap.go
+++ b/internal/configs/hcl2shim/flatmap.go
@@ -197,7 +197,7 @@ func hcl2ValueFromFlatmapPrimitive(m map[string]string, key string, ty cty.Type)
 	if err != nil {
 		// This should never happen for _valid_ input, but flatmap data might
 		// be tampered with by the user and become invalid.
-		return cty.DynamicVal, fmt.Errorf("invalid value for %q in state: %s", key, err)
+		return cty.DynamicVal, fmt.Errorf("invalid value for %q in state: %w", key, err)
 	}
 
 	return val, nil
@@ -234,7 +234,7 @@ func hcl2ValueFromFlatmapTuple(m map[string]string, prefix string, etys []cty.Ty
 
 	count, err := strconv.Atoi(countStr)
 	if err != nil {
-		return cty.DynamicVal, fmt.Errorf("invalid count value for %q in state: %s", prefix, err)
+		return cty.DynamicVal, fmt.Errorf("invalid count value for %q in state: %w", prefix, err)
 	}
 	if count != len(etys) {
 		return cty.DynamicVal, fmt.Errorf("wrong number of values for %q in state: got %d, but need %d", prefix, count, len(etys))
@@ -319,7 +319,7 @@ func hcl2ValueFromFlatmapList(m map[string]string, prefix string, ty cty.Type) (
 
 	count, err := strconv.Atoi(countStr)
 	if err != nil {
-		return cty.DynamicVal, fmt.Errorf("invalid count value for %q in state: %s", prefix, err)
+		return cty.DynamicVal, fmt.Errorf("invalid count value for %q in state: %w", prefix, err)
 	}
 
 	ety := ty.ElementType()

--- a/internal/configs/hcl2shim/paths.go
+++ b/internal/configs/hcl2shim/paths.go
@@ -90,7 +90,7 @@ func requiresReplacePath(k string, ty cty.Type) (cty.Path, error) {
 
 	path, err := pathFromFlatmapKeyObject(k, ty.AttributeTypes())
 	if err != nil {
-		return path, fmt.Errorf("[%s] %s", k, err)
+		return path, fmt.Errorf("[%s] %w", k, err)
 	}
 	return path, nil
 }

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -192,7 +192,7 @@ func (b *binary) StateFromFile(filename string) (*states.State, error) {
 
 	stateFile, err := statefile.Read(f)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading statefile: %s", err)
+		return nil, fmt.Errorf("Error reading statefile: %w", err)
 	}
 	return stateFile.State, nil
 }
@@ -220,7 +220,7 @@ func (b *binary) SetLocalState(state *states.State) error {
 	path := b.Path("terraform.tfstate")
 	f, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("failed to create temporary state file %s: %s", path, err)
+		return fmt.Errorf("failed to create temporary state file %s: %w", path, err)
 	}
 	defer f.Close()
 

--- a/internal/getmodules/getter.go
+++ b/internal/getmodules/getter.go
@@ -131,11 +131,11 @@ func (g reusingGetter) getWithGoGetter(ctx context.Context, instPath, packageAdd
 		log.Printf("[TRACE] getmodules: copying previous install of %q from %s to %s", packageAddr, prevDir, instPath)
 		err := os.Mkdir(instPath, os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("failed to create directory %s: %s", instPath, err)
+			return fmt.Errorf("failed to create directory %s: %w", instPath, err)
 		}
 		err = copy.CopyDir(instPath, prevDir)
 		if err != nil {
-			return fmt.Errorf("failed to copy from %s to %s: %s", prevDir, instPath, err)
+			return fmt.Errorf("failed to copy from %s to %s: %w", prevDir, instPath, err)
 		}
 	} else {
 		log.Printf("[TRACE] getmodules: fetching %q to %q", packageAddr, instPath)

--- a/internal/getproviders/filesystem_search.go
+++ b/internal/getproviders/filesystem_search.go
@@ -47,7 +47,7 @@ func SearchLocalDirectory(baseDir string) (map[addrs.Provider]PackageMetaList, e
 
 	err := filepath.Walk(baseDir, func(fullPath string, info os.FileInfo, err error) error {
 		if err != nil {
-			return fmt.Errorf("cannot search %s: %s", fullPath, err)
+			return fmt.Errorf("cannot search %s: %w", fullPath, err)
 		}
 
 		// There are two valid directory structures that we support here...

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -124,7 +124,7 @@ func (s *HTTPMirrorSource) AvailableVersions(ctx context.Context, provider addrs
 
 	dec := json.NewDecoder(body)
 	if err := dec.Decode(&bodyContent); err != nil {
-		return nil, nil, s.errQueryFailed(provider, fmt.Errorf("invalid response content from mirror server: %s", err))
+		return nil, nil, s.errQueryFailed(provider, fmt.Errorf("invalid response content from mirror server: %w", err))
 	}
 
 	if len(bodyContent.Versions) == 0 {
@@ -192,7 +192,7 @@ func (s *HTTPMirrorSource) PackageMeta(ctx context.Context, provider addrs.Provi
 
 	dec := json.NewDecoder(body)
 	if err := dec.Decode(&bodyContent); err != nil {
-		return PackageMeta{}, s.errQueryFailed(provider, fmt.Errorf("invalid response content from mirror server: %s", err))
+		return PackageMeta{}, s.errQueryFailed(provider, fmt.Errorf("invalid response content from mirror server: %w", err))
 	}
 
 	archiveMeta, ok := bodyContent.Archives[target.String()]
@@ -209,7 +209,7 @@ func (s *HTTPMirrorSource) PackageMeta(ctx context.Context, provider addrs.Provi
 	if err != nil {
 		return PackageMeta{}, s.errQueryFailed(
 			provider,
-			fmt.Errorf("provider mirror returned invalid URL %q: %s", archiveMeta.RelativeURL, err),
+			fmt.Errorf("provider mirror returned invalid URL %q: %w", archiveMeta.RelativeURL, err),
 		)
 	}
 	absURL := finalURL.ResolveReference(relURL)
@@ -231,7 +231,7 @@ func (s *HTTPMirrorSource) PackageMeta(ctx context.Context, provider addrs.Provi
 			if err != nil {
 				return PackageMeta{}, s.errQueryFailed(
 					provider,
-					fmt.Errorf("provider mirror returned invalid provider hash %q: %s", hashStr, err),
+					fmt.Errorf("provider mirror returned invalid provider hash %q: %w", hashStr, err),
 				)
 			}
 			hashes = append(hashes, hash)
@@ -267,7 +267,7 @@ func (s *HTTPMirrorSource) mirrorHost() (svchost.Hostname, error) {
 func (s *HTTPMirrorSource) mirrorHostCredentials() (svcauth.HostCredentials, error) {
 	hostname, err := s.mirrorHost()
 	if err != nil {
-		return nil, fmt.Errorf("invalid provider mirror base URL %s: %s", s.baseURL.String(), err)
+		return nil, fmt.Errorf("invalid provider mirror base URL %s: %w", s.baseURL.String(), err)
 	}
 
 	if s.creds == nil {
@@ -304,7 +304,7 @@ func (s *HTTPMirrorSource) get(ctx context.Context, relativePath string) (status
 	req.Request.Header.Set(terraformVersionHeader, version.String())
 	creds, err := s.mirrorHostCredentials()
 	if err != nil {
-		return 0, nil, endpointURL, fmt.Errorf("failed to determine request credentials: %s", err)
+		return 0, nil, endpointURL, fmt.Errorf("failed to determine request credentials: %w", err)
 	}
 	if creds != nil {
 		// Note that if the initial requests gets redirected elsewhere
@@ -340,7 +340,7 @@ func (s *HTTPMirrorSource) get(ctx context.Context, relativePath string) (status
 		ct := resp.Header.Get("Content-Type")
 		mt, params, err := mime.ParseMediaType(ct)
 		if err != nil {
-			return 0, nil, finalURL, fmt.Errorf("response has invalid Content-Type: %s", err)
+			return 0, nil, finalURL, fmt.Errorf("response has invalid Content-Type: %w", err)
 		}
 		if mt != "application/json" {
 			return 0, nil, finalURL, fmt.Errorf("response has invalid Content-Type: must be application/json")

--- a/internal/getproviders/multi_source.go
+++ b/internal/getproviders/multi_source.go
@@ -158,7 +158,7 @@ func ParseMultiSourceMatchingPatterns(strs []string) (MultiSourceMatchingPattern
 			} else {
 				normalHost, err := svchost.ForComparison(givenHost)
 				if err != nil {
-					return nil, fmt.Errorf("invalid hostname in provider matching pattern %q: %s", str, err)
+					return nil, fmt.Errorf("invalid hostname in provider matching pattern %q: %w", str, err)
 				}
 
 				// The remaining code below deals only with the namespace/type portions.

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -227,7 +227,7 @@ func (a packageHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 
 	matches, err := PackageMatchesAnyHash(localLocation, a.RequiredHashes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify provider package checksums: %s", err)
+		return nil, fmt.Errorf("failed to verify provider package checksums: %w", err)
 	}
 
 	if matches {
@@ -286,7 +286,7 @@ func (a archiveHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 
 	gotHash, err := PackageHashLegacyZipSHA(archiveLocation)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute checksum for %s: %s", archiveLocation, err)
+		return nil, fmt.Errorf("failed to compute checksum for %s: %w", archiveLocation, err)
 	}
 	wantHash := HashLegacyZipSHAFromSHA(a.WantSHA256Sum)
 	if gotHash != wantHash {
@@ -342,7 +342,7 @@ func (m matchingChecksumAuthentication) AuthenticatePackage(location PackageLoca
 	// Decode the ASCII checksum into a byte array for comparison.
 	var gotSHA256Sum [sha256.Size]byte
 	if _, err := hex.Decode(gotSHA256Sum[:], checksum); err != nil {
-		return nil, fmt.Errorf("checksum list has invalid SHA256 hash %q: %s", string(checksum), err)
+		return nil, fmt.Errorf("checksum list has invalid SHA256 hash %q: %w", string(checksum), err)
 	}
 
 	// If the checksums don't match, authentication fails.
@@ -406,7 +406,7 @@ func (s signatureAuthentication) shouldEnforceGPGValidation() (bool, error) {
 func (s signatureAuthentication) AuthenticatePackage(location PackageLocation) (*PackageAuthenticationResult, error) {
 	shouldValidate, err := s.shouldEnforceGPGValidation()
 	if err != nil {
-		return nil, fmt.Errorf("error determining if GPG validation should be enforced for pacakage %s: %s", location.String(), err.Error())
+		return nil, fmt.Errorf("error determining if GPG validation should be enforced for pacakage %s: %w", location.String(), err)
 	}
 
 	if !shouldValidate {
@@ -488,7 +488,7 @@ func (s signatureAuthentication) findSigningKey() (*SigningKey, string, error) {
 	for _, key := range s.Keys {
 		keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(key.ASCIIArmor))
 		if err != nil {
-			return nil, "", fmt.Errorf("error decoding signing key: %s", err)
+			return nil, "", fmt.Errorf("error decoding signing key: %w", err)
 		}
 
 		entity, err := openpgp.CheckDetachedSignature(keyring, bytes.NewReader(s.Document), bytes.NewReader(s.Signature), openpgpConfig)
@@ -501,7 +501,7 @@ func (s signatureAuthentication) findSigningKey() (*SigningKey, string, error) {
 
 		// Any other signature error is terminal.
 		if err != nil {
-			return nil, "", fmt.Errorf("error checking signature: %s", err)
+			return nil, "", fmt.Errorf("error checking signature: %w", err)
 		}
 
 		keyID := "n/a"

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -243,7 +243,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 		if err != nil {
 			return PackageMeta{}, c.errQueryFailed(
 				provider,
-				fmt.Errorf("registry response includes invalid version string %q: %s", versionStr, err),
+				fmt.Errorf("registry response includes invalid version string %q: %w", versionStr, err),
 			)
 		}
 		protoVersions = append(protoVersions, v)
@@ -282,7 +282,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 
 	downloadURL, err := url.Parse(body.DownloadURL)
 	if err != nil {
-		return PackageMeta{}, fmt.Errorf("registry response includes invalid download URL: %s", err)
+		return PackageMeta{}, fmt.Errorf("registry response includes invalid download URL: %w", err)
 	}
 	downloadURL = resp.Request.URL.ResolveReference(downloadURL)
 	if downloadURL.Scheme != "http" && downloadURL.Scheme != "https" {
@@ -305,7 +305,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	if len(body.SHA256Sum) != sha256.Size*2 { // *2 because it's hex-encoded
 		return PackageMeta{}, c.errQueryFailed(
 			provider,
-			fmt.Errorf("registry response includes invalid SHA256 hash %q: %s", body.SHA256Sum, err),
+			fmt.Errorf("registry response includes invalid SHA256 hash %q: %w", body.SHA256Sum, err),
 		)
 	}
 
@@ -314,13 +314,13 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	if err != nil {
 		return PackageMeta{}, c.errQueryFailed(
 			provider,
-			fmt.Errorf("registry response includes invalid SHA256 hash %q: %s", body.SHA256Sum, err),
+			fmt.Errorf("registry response includes invalid SHA256 hash %q: %w", body.SHA256Sum, err),
 		)
 	}
 
 	shasumsURL, err := url.Parse(body.SHA256SumsURL)
 	if err != nil {
-		return PackageMeta{}, fmt.Errorf("registry response includes invalid SHASUMS URL: %s", err)
+		return PackageMeta{}, fmt.Errorf("registry response includes invalid SHASUMS URL: %w", err)
 	}
 	shasumsURL = resp.Request.URL.ResolveReference(shasumsURL)
 	if shasumsURL.Scheme != "http" && shasumsURL.Scheme != "https" {
@@ -330,12 +330,12 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	if err != nil {
 		return PackageMeta{}, c.errQueryFailed(
 			provider,
-			fmt.Errorf("failed to retrieve authentication checksums for provider: %s", err),
+			fmt.Errorf("failed to retrieve authentication checksums for provider: %w", err),
 		)
 	}
 	signatureURL, err := url.Parse(body.SHA256SumsSignatureURL)
 	if err != nil {
-		return PackageMeta{}, fmt.Errorf("registry response includes invalid SHASUMS signature URL: %s", err)
+		return PackageMeta{}, fmt.Errorf("registry response includes invalid SHASUMS signature URL: %w", err)
 	}
 	signatureURL = resp.Request.URL.ResolveReference(signatureURL)
 	if signatureURL.Scheme != "http" && signatureURL.Scheme != "https" {
@@ -345,7 +345,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	if err != nil {
 		return PackageMeta{}, c.errQueryFailed(
 			provider,
-			fmt.Errorf("failed to retrieve cryptographic signature for provider: %s", err),
+			fmt.Errorf("failed to retrieve cryptographic signature for provider: %w", err),
 		)
 	}
 
@@ -378,7 +378,7 @@ func (c *registryClient) findClosestProtocolCompatibleVersion(ctx context.Contex
 		if err != nil {
 			return UnspecifiedVersion, ErrQueryFailed{
 				Provider: provider,
-				Wrapped:  fmt.Errorf("registry response includes invalid version string %q: %s", versionStr, err),
+				Wrapped:  fmt.Errorf("registry response includes invalid version string %q: %w", versionStr, err),
 			}
 		}
 		versionList = append(versionList, v)
@@ -394,7 +394,7 @@ FindMatch:
 			if err != nil {
 				return UnspecifiedVersion, ErrQueryFailed{
 					Provider: provider,
-					Wrapped:  fmt.Errorf("registry response includes invalid protocol string %q: %s", protoStr, err),
+					Wrapped:  fmt.Errorf("registry response includes invalid protocol string %q: %w", protoStr, err),
 				}
 			}
 			if protoVersions.Has(p) {

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -70,7 +70,7 @@ func (s *RegistrySource) AvailableVersions(ctx context.Context, provider addrs.P
 		if err != nil {
 			return nil, nil, ErrQueryFailed{
 				Provider: provider,
-				Wrapped:  fmt.Errorf("registry response includes invalid version string %q: %s", str, err),
+				Wrapped:  fmt.Errorf("registry response includes invalid version string %q: %w", str, err),
 			}
 		}
 		ret = append(ret, v)
@@ -142,7 +142,7 @@ func (s *RegistrySource) registryClient(hostname svchost.Hostname) (*registryCli
 		// This indicates that a credentials helper failed, which means we
 		// can't do anything better than just pass through the helper's
 		// own error message.
-		return nil, fmt.Errorf("failed to retrieve credentials for %s: %s", hostname, err)
+		return nil, fmt.Errorf("failed to retrieve credentials for %s: %w", hostname, err)
 	}
 
 	return newRegistryClient(url, creds), nil

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -84,14 +84,14 @@ func ReadManifestSnapshot(r io.Reader) (Manifest, error) {
 	var read manifestSnapshotFile
 	err = json.Unmarshal(src, &read)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling snapshot: %v", err)
+		return nil, fmt.Errorf("error unmarshalling snapshot: %w", err)
 	}
 	new := make(Manifest)
 	for _, record := range read.Records {
 		if record.VersionStr != "" {
 			record.Version, err = version.NewVersion(record.VersionStr)
 			if err != nil {
-				return nil, fmt.Errorf("invalid version %q for %s: %s", record.VersionStr, record.Key, err)
+				return nil, fmt.Errorf("invalid version %q for %s: %w", record.VersionStr, record.Key, err)
 			}
 		}
 

--- a/internal/providercache/cached_provider.go
+++ b/internal/providercache/cached_provider.go
@@ -108,7 +108,7 @@ func (cp *CachedProvider) ExecutableFile() (string, error) {
 	if err != nil {
 		// If the directory itself doesn't exist or isn't readable then we
 		// can't access an executable in it.
-		return "", fmt.Errorf("could not read package directory: %s", err)
+		return "", fmt.Errorf("could not read package directory: %w", err)
 	}
 
 	// For a provider named e.g. tf.example.com/awesomecorp/happycloud, we

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -65,7 +65,7 @@ func (d *Dir) LinkFromOtherCache(entry *CachedProvider, allowedHashes []getprovi
 	if len(allowedHashes) > 0 {
 		if matches, err := entry.MatchesAnyHash(allowedHashes); err != nil {
 			return fmt.Errorf(
-				"failed to calculate checksum for cached copy of %s %s in %s: %s",
+				"failed to calculate checksum for cached copy of %s %s in %s: %w",
 				entry.Provider, entry.Version, d.baseDir, err,
 			)
 		} else if !matches {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -444,7 +444,7 @@ NeedProvider:
 						cb(provider, version, i.globalCacheDir.baseDir)
 					}
 					if _, err := cached.ExecutableFile(); err != nil {
-						err := fmt.Errorf("provider binary not found: %s", err)
+						err := fmt.Errorf("provider binary not found: %w", err)
 						errs[provider] = err
 						if cb := evts.LinkFromCacheFailure; cb != nil {
 							cb(provider, version, err)
@@ -506,7 +506,7 @@ NeedProvider:
 					}
 					newHash, err := cached.Hash()
 					if err != nil {
-						err := fmt.Errorf("after linking %s from provider cache at %s, failed to compute a checksum for it: %s", provider, i.globalCacheDir.baseDir, err)
+						err := fmt.Errorf("after linking %s from provider cache at %s, failed to compute a checksum for it: %w", provider, i.globalCacheDir.baseDir, err)
 						errs[provider] = err
 						if cb := evts.LinkFromCacheFailure; cb != nil {
 							cb(provider, version, err)
@@ -593,7 +593,7 @@ NeedProvider:
 			continue
 		}
 		if _, err := new.ExecutableFile(); err != nil {
-			err := fmt.Errorf("provider binary not found: %s", err)
+			err := fmt.Errorf("provider binary not found: %w", err)
 			errs[provider] = err
 			if cb := evts.FetchPackageFailure; cb != nil {
 				cb(provider, version, err)
@@ -630,7 +630,7 @@ NeedProvider:
 				continue
 			}
 			if _, err := new.ExecutableFile(); err != nil {
-				err := fmt.Errorf("provider binary not found: %s", err)
+				err := fmt.Errorf("provider binary not found: %w", err)
 				errs[provider] = err
 				if cb := evts.FetchPackageFailure; cb != nil {
 					cb(provider, version, err)
@@ -666,7 +666,7 @@ NeedProvider:
 		}
 		newHash, err := new.Hash()
 		if err != nil {
-			err := fmt.Errorf("after installing %s, failed to compute a checksum for it: %s", provider, err)
+			err := fmt.Errorf("after installing %s, failed to compute a checksum for it: %w", provider, err)
 			errs[provider] = err
 			if cb := evts.FetchPackageFailure; cb != nil {
 				cb(provider, version, err)

--- a/internal/providercache/package_install.go
+++ b/internal/providercache/package_install.go
@@ -38,7 +38,7 @@ func installFromHTTPURL(ctx context.Context, meta getproviders.PackageMeta, targ
 	httpClient := httpclient.New()
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("invalid provider download request: %s", err)
+		return nil, fmt.Errorf("invalid provider download request: %w", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -114,7 +114,7 @@ func installFromLocalArchive(ctx context.Context, meta getproviders.PackageMeta,
 	if len(allowedHashes) > 0 {
 		if matches, err := meta.MatchesAnyHash(allowedHashes); err != nil {
 			return authResult, fmt.Errorf(
-				"failed to calculate checksum for %s %s package at %s: %s",
+				"failed to calculate checksum for %s %s package at %s: %w",
 				meta.Provider, meta.Version, meta.Location, err,
 			)
 		} else if !matches {
@@ -152,11 +152,11 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 
 	absNew, err := filepath.Abs(targetDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make target path %s absolute: %s", targetDir, err)
+		return nil, fmt.Errorf("failed to make target path %s absolute: %w", targetDir, err)
 	}
 	absCurrent, err := filepath.Abs(sourceDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make source path %s absolute: %s", sourceDir, err)
+		return nil, fmt.Errorf("failed to make source path %s absolute: %w", sourceDir, err)
 	}
 
 	// Before we do anything else, we'll do a quick check to make sure that
@@ -166,7 +166,7 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 	if same, err := copy.SameFile(absNew, absCurrent); same {
 		return nil, fmt.Errorf("cannot install existing provider directory %s to itself", targetDir)
 	} else if err != nil {
-		return nil, fmt.Errorf("failed to determine if %s and %s are the same: %s", sourceDir, targetDir, err)
+		return nil, fmt.Errorf("failed to determine if %s and %s are the same: %w", sourceDir, targetDir, err)
 	}
 
 	var authResult *getproviders.PackageAuthenticationResult
@@ -204,7 +204,7 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 	if suitableHashCount > 0 {
 		if matches, err := meta.MatchesAnyHash(allowedHashes); err != nil {
 			return authResult, fmt.Errorf(
-				"failed to calculate checksum for %s %s package at %s: %s",
+				"failed to calculate checksum for %s %s package at %s: %w",
 				meta.Provider, meta.Version, meta.Location, err,
 			)
 		} else if !matches {
@@ -218,7 +218,7 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 	// Delete anything that's already present at this path first.
 	err = os.RemoveAll(targetDir)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("failed to remove existing %s before linking it to %s: %s", sourceDir, targetDir, err)
+		return nil, fmt.Errorf("failed to remove existing %s before linking it to %s: %w", sourceDir, targetDir, err)
 	}
 
 	// We'll prefer to create a symlink if possible, but we'll fall back to
@@ -237,7 +237,7 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 	parentDir := filepath.Dir(absNew)
 	err = os.MkdirAll(parentDir, 0755)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create parent directories leading to %s: %s", targetDir, err)
+		return nil, fmt.Errorf("failed to create parent directories leading to %s: %w", targetDir, err)
 	}
 
 	err = os.Symlink(linkTarget, absNew)
@@ -251,11 +251,11 @@ func installFromLocalDir(ctx context.Context, meta getproviders.PackageMeta, tar
 	// which would otherwise be a symlink.
 	err = os.Mkdir(absNew, 0755)
 	if err != nil && os.IsExist(err) {
-		return nil, fmt.Errorf("failed to create directory %s: %s", absNew, err)
+		return nil, fmt.Errorf("failed to create directory %s: %w", absNew, err)
 	}
 	err = copy.CopyDir(absNew, absCurrent)
 	if err != nil {
-		return nil, fmt.Errorf("failed to either symlink or copy %s to %s: %s", absCurrent, absNew, err)
+		return nil, fmt.Errorf("failed to either symlink or copy %s to %s: %w", absCurrent, absNew, err)
 	}
 
 	// If we got here then apparently our copy succeeded, so we're done.

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -230,7 +230,7 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 	// there should be no body, but save it for logging
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading response body from registry: %s", err)
+		return "", fmt.Errorf("error reading response body from registry: %w", err)
 	}
 
 	switch resp.StatusCode {
@@ -263,7 +263,7 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 	if strings.HasPrefix(location, "/") || strings.HasPrefix(location, "./") || strings.HasPrefix(location, "../") {
 		locationURL, err := url.Parse(location)
 		if err != nil {
-			return "", fmt.Errorf("invalid relative URL for %q: %s", module, err)
+			return "", fmt.Errorf("invalid relative URL for %q: %w", module, err)
 		}
 		locationURL = download.ResolveReference(locationURL)
 		location = locationURL.String()

--- a/internal/replacefile/writefile.go
+++ b/internal/replacefile/writefile.go
@@ -37,7 +37,7 @@ func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
 	}
 	f, err := os.CreateTemp(dir, file) // alongside target file and with a similar name
 	if err != nil {
-		return fmt.Errorf("cannot create temporary file to update %s: %s", filename, err)
+		return fmt.Errorf("cannot create temporary file to update %s: %w", filename, err)
 	}
 	tmpName := f.Name()
 	moved := false
@@ -54,7 +54,7 @@ func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
 	// not be effective on all platforms, but should at least work on
 	// Unix-like targets and should be harmless elsewhere.
 	if err := os.Chmod(tmpName, perm); err != nil {
-		return fmt.Errorf("cannot set mode for temporary file %s: %s", tmpName, err)
+		return fmt.Errorf("cannot set mode for temporary file %s: %w", tmpName, err)
 	}
 
 	// Write the credentials to the temporary file, then immediately close
@@ -63,7 +63,7 @@ func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
 	_, err = f.Write(data)
 	f.Close()
 	if err != nil {
-		return fmt.Errorf("cannot write to temporary file %s: %s", tmpName, err)
+		return fmt.Errorf("cannot write to temporary file %s: %w", tmpName, err)
 	}
 
 	// Temporary file now replaces the original file, as atomically as
@@ -71,7 +71,7 @@ func AtomicWriteFile(filename string, data []byte, perm os.FileMode) error {
 	// containing only a partial JSON object.)
 	err = AtomicRename(tmpName, filename)
 	if err != nil {
-		return fmt.Errorf("failed to replace %s with temporary file %s: %s", filename, tmpName, err)
+		return fmt.Errorf("failed to replace %s with temporary file %s: %w", filename, tmpName, err)
 	}
 
 	moved = true

--- a/internal/terminal/impl_windows.go
+++ b/internal/terminal/impl_windows.go
@@ -37,7 +37,7 @@ func configureOutputHandle(f *os.File) (*OutputStream, error) {
 		// the console is just ambiently associated with our process.
 		err := SetConsoleOutputCP(CP_UTF8)
 		if err != nil {
-			return nil, fmt.Errorf("failed to set the console to UTF-8 mode; you may need to use a newer version of Windows: %s", err)
+			return nil, fmt.Errorf("failed to set the console to UTF-8 mode; you may need to use a newer version of Windows: %w", err)
 		}
 
 		// If the console also allows us to turn on
@@ -95,7 +95,7 @@ func configureInputHandle(f *os.File) (*InputStream, error) {
 		// the console is just ambiently associated with our process.
 		err := SetConsoleCP(CP_UTF8)
 		if err != nil {
-			return nil, fmt.Errorf("failed to set the console to UTF-8 mode; you may need to use a newer version of Windows: %s", err)
+			return nil, fmt.Errorf("failed to set the console to UTF-8 mode; you may need to use a newer version of Windows: %w", err)
 		}
 		ret.isTerminal = staticTrue
 		return ret, nil


### PR DESCRIPTION
This wraps formatted errors in:

internal/terminal
internal/replacefile
internal/registry
internal/providercache
internal/modsdir
internal/getproviders
internal/getmodules
internal/e2e
internal/configs
internal/communicator


This wraps the errors using the %w directive instead of %v or %s. I left the tests alone.

part of https://github.com/opentffoundation/opentf/issues/395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.