### PR TITLE
Clean up frontmatter sections in the docs

### DIFF
--- a/website/docs/cli/auth/index.mdx
+++ b/website/docs/cli/auth/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Authentication - OpenTF CLI
 description: >-
   Documentation about the login and logout commands that help automate getting
   an API token for your cloud backend account.

--- a/website/docs/cli/cloud/command-line-arguments.mdx
+++ b/website/docs/cli/cloud/command-line-arguments.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Command Line Arguments
 description: Command Line Arguments
 ---
 

--- a/website/docs/cli/cloud/index.mdx
+++ b/website/docs/cli/cloud/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Using the Cloud Backend - OpenTF CLI
 description: >-
   Learn how to use a cloud backend on the command line with the OpenTF CLI.
 ---

--- a/website/docs/cli/cloud/migrating.mdx
+++ b/website/docs/cli/cloud/migrating.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Initializing and Migrating to a Cloud Backend - OpenTF CLI
 description: >-
   Learn how to use the OpenTF CLI to migrate local or remote state to a Cloud Backend.
 ---

--- a/website/docs/cli/cloud/settings.mdx
+++ b/website/docs/cli/cloud/settings.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Cloud Backend Settings - OpenTF CLI
 description: >-
   Configure the Cloud Backend CLI integration.
 ---

--- a/website/docs/cli/code/index.mdx
+++ b/website/docs/cli/code/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Writing and Modifying Code - OpenTF CLI
 description: >-
   Learn commands that help validate, format, and upgrade code written in the
   OpenTF Configuration Language.

--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: apply'
 description: >-
   The opentf apply command executes the actions proposed in a OpenTF plan
   to create, update, or destroy infrastructure.

--- a/website/docs/cli/commands/console.mdx
+++ b/website/docs/cli/commands/console.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: console'
 description: >-
   The opentf console command provides an interactive console for evaluating
   expressions.

--- a/website/docs/cli/commands/destroy.mdx
+++ b/website/docs/cli/commands/destroy.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: destroy'
 description: >-
   The opentf destroy command destroys all objects managed by a OpenTF
   configuration.

--- a/website/docs/cli/commands/env.mdx
+++ b/website/docs/cli/commands/env.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: env'
 description: >-
   The opentf env command is a deprecated form of the opentf workspace
   command.

--- a/website/docs/cli/commands/fmt.mdx
+++ b/website/docs/cli/commands/fmt.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: fmt'
 description: >-
   The opentf fmt command rewrites configuration files to a canonical format
   and style.

--- a/website/docs/cli/commands/force-unlock.mdx
+++ b/website/docs/cli/commands/force-unlock.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: force-unlock'
 description: >-
   The opentf force-unlock command unlocks the state for a configuration. It
   does not modify your infrastructure.

--- a/website/docs/cli/commands/get.mdx
+++ b/website/docs/cli/commands/get.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: get'
 description: The opentf get command downloads and updates modules.
 ---
 

--- a/website/docs/cli/commands/graph.mdx
+++ b/website/docs/cli/commands/graph.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: graph'
 description: >-
   The opentf graph command generates a visual representation of a
   configuration or execution plan that you can use to generate charts.

--- a/website/docs/cli/commands/import.mdx
+++ b/website/docs/cli/commands/import.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: import'
 description: The opentf import command brings existing resources into OpenTF state.
 ---
 

--- a/website/docs/cli/commands/index.mdx
+++ b/website/docs/cli/commands/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Basic CLI Features
 description: An introduction to the opentf command and its available subcommands.
 ---
 

--- a/website/docs/cli/commands/init.mdx
+++ b/website/docs/cli/commands/init.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: init'
 description: >-
   The opentf init command initializes a working directory containing
   configuration files and installs plugins for required providers.

--- a/website/docs/cli/commands/login.mdx
+++ b/website/docs/cli/commands/login.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: login'
 description: >-
   The opentf login command can be used to automatically obtain and save an
   API token for any host that offers OpenTF-compatible services.

--- a/website/docs/cli/commands/logout.mdx
+++ b/website/docs/cli/commands/logout.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: logout'
 description: >-
   The opentf logout command is used to remove credentials stored by opentf
   login.

--- a/website/docs/cli/commands/output.mdx
+++ b/website/docs/cli/commands/output.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: output'
 description: >-
   The `opentf output` command is used to extract the value of an output
   variable from the state file.

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: plan'
 description: >-
   The opentf plan command creates an execution plan with a preview of the
   changes that OpenTF will make to your infrastructure.

--- a/website/docs/cli/commands/providers.mdx
+++ b/website/docs/cli/commands/providers.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: providers'
 description: >-
   The opentf providers command prints information about the providers
   required in the current configuration.

--- a/website/docs/cli/commands/providers/_category_.json
+++ b/website/docs/cli/commands/providers/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Command: providers"
+}

--- a/website/docs/cli/commands/providers/lock.mdx
+++ b/website/docs/cli/commands/providers/lock.mdx
@@ -1,11 +1,10 @@
 ---
-page_title: 'Command: providers lock'
 description: |-
   The `opentf providers lock` command adds new provider selection information
   to the dependency lock file without initializing the referenced providers.
 ---
 
-# Command: opentf providers lock
+# Command: providers lock
 
 The `opentf providers lock` consults upstream registries (by default) in
 order to write provider dependency information into

--- a/website/docs/cli/commands/providers/mirror.mdx
+++ b/website/docs/cli/commands/providers/mirror.mdx
@@ -1,12 +1,11 @@
 ---
-page_title: 'Command: providers mirror'
 description: |-
   The `opentf providers mirror` command downloads the providers required
   for the current configuration and copies them into a directory in the local
   filesystem.
 ---
 
-# Command: opentf providers mirror
+# Command: providers mirror
 
 The `opentf providers mirror` command downloads the providers required
 for the current configuration and copies them into a directory in the local

--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: providers schema'
 description: >-
   The `opentf providers schema` command prints detailed schemas for the
   providers used
@@ -7,7 +6,7 @@ description: >-
   in the current configuration.
 ---
 
-# Command: opentf providers schema
+# Command: providers schema
 
 The `opentf providers schema` command is used to print detailed schemas for the providers used in the current configuration.
 

--- a/website/docs/cli/commands/refresh.mdx
+++ b/website/docs/cli/commands/refresh.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: refresh'
 description: |-
   The `opentf refresh` command reads the current settings from all managed
   remote objects and updates the OpenTF state to match.

--- a/website/docs/cli/commands/show.mdx
+++ b/website/docs/cli/commands/show.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: show'
 description: >-
   The `opentf show` command is used to provide human-readable output from a
   state or plan file. This can be used to inspect a plan to ensure that the

--- a/website/docs/cli/commands/state/index.mdx
+++ b/website/docs/cli/commands/state/index.mdx
@@ -1,9 +1,8 @@
 ---
-page_title: 'Command: state'
 description: The `opentf state` command is used for advanced state management.
 ---
 
-# State Command
+# Command: state
 
 The `opentf state` command is used for advanced state management.
 As your OpenTF usage becomes more advanced, there are some cases where

--- a/website/docs/cli/commands/state/list.mdx
+++ b/website/docs/cli/commands/state/list.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state list'
 description: >-
   The opentf state list command is used to list resources within a OpenTF
   state.

--- a/website/docs/cli/commands/state/mv.mdx
+++ b/website/docs/cli/commands/state/mv.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state mv'
 description: >-
   The `opentf state mv` command changes bindings in OpenTF state,
   associating existing remote objects with new resource instances.

--- a/website/docs/cli/commands/state/pull.mdx
+++ b/website/docs/cli/commands/state/pull.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state pull'
 description: >-
   The `opentf state pull` command is used to manually download and output the
   state from remote state.

--- a/website/docs/cli/commands/state/push.mdx
+++ b/website/docs/cli/commands/state/push.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state push'
 description: The `opentf state push` command pushes items to the OpenTF state.
 ---
 

--- a/website/docs/cli/commands/state/replace-provider.mdx
+++ b/website/docs/cli/commands/state/replace-provider.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state replace-provider'
 description: >-
   The `opentf state replace-provider` command replaces the provider for
   resources in the OpenTF state.

--- a/website/docs/cli/commands/state/rm.mdx
+++ b/website/docs/cli/commands/state/rm.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state rm'
 description: >-
   The `opentf state rm` command removes bindings from the OpenTF state,
   causing OpenTF to "forget about" existing objects.

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: state show'
 description: >-
   The `opentf state show` command is used to show the attributes of a single
   resource in the OpenTF state.

--- a/website/docs/cli/commands/taint.mdx
+++ b/website/docs/cli/commands/taint.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: taint'
 description: |-
   The `opentf taint` command informs OpenTF that a particular object
   is damaged or degraded.

--- a/website/docs/cli/commands/test.mdx
+++ b/website/docs/cli/commands/test.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: test'
 description: Part of the ongoing design research for module integration testing.
 ---
 

--- a/website/docs/cli/commands/untaint.mdx
+++ b/website/docs/cli/commands/untaint.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: untaint'
 description: |-
   The `opentf untaint` command tells OpenTF that an object is functioning
   correctly, even though its creation failed or it was previously manually

--- a/website/docs/cli/commands/validate.mdx
+++ b/website/docs/cli/commands/validate.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: validate'
 description: >-
   The `opentf validate` command is used to validate the syntax of the
   opentf files.

--- a/website/docs/cli/commands/version.mdx
+++ b/website/docs/cli/commands/version.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: version'
 description: >-
   The opentf version command displays the OpenTF version and the version
   of all installed plugins.

--- a/website/docs/cli/commands/workspace/delete.mdx
+++ b/website/docs/cli/commands/workspace/delete.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: workspace delete'
 description: The opentf workspace delete command is used to delete a workspace.
 ---
 

--- a/website/docs/cli/commands/workspace/index.mdx
+++ b/website/docs/cli/commands/workspace/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: workspace'
 description: The workspace command helps you manage workspaces.
 ---
 

--- a/website/docs/cli/commands/workspace/list.mdx
+++ b/website/docs/cli/commands/workspace/list.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: workspace list'
 description: The opentf workspace list command is used to list all existing workspaces.
 ---
 

--- a/website/docs/cli/commands/workspace/new.mdx
+++ b/website/docs/cli/commands/workspace/new.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: workspace new'
 description: The opentf workspace new command is used to create a new workspace.
 ---
 

--- a/website/docs/cli/commands/workspace/select.mdx
+++ b/website/docs/cli/commands/workspace/select.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: workspace select'
 description: The opentf workspace select command is used to choose a workspace.
 ---
 

--- a/website/docs/cli/commands/workspace/show.mdx
+++ b/website/docs/cli/commands/workspace/show.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Command: workspace show'
 description: The opentf workspace show command is used to output the current workspace.
 ---
 

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: CLI Configuration
+title: CLI Configuration File
 description: >-
   Learn to use the CLI configuration file to customize your CLI settings,
   including credentials, plugin caching, provider installation methods, etc.

--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Environment Variables
 description: >-
   Learn to use environment variables to change OpenTF's default behavior.
   Configure log content and output, set variables, and more.

--- a/website/docs/cli/config/index.mdx
+++ b/website/docs/cli/config/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: CLI Configuration - OpenTF CLI
 description: >-
   Find documentation about the CLI config file and customizing OpenTF
   environment variables.

--- a/website/docs/cli/import/importability.mdx
+++ b/website/docs/cli/import/importability.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Import: Resource Importability'
 description: |-
   Each resource in OpenTF must implement some basic logic to become
   importable. As a result, you cannot import all OpenTF resources.

--- a/website/docs/cli/import/index.mdx
+++ b/website/docs/cli/import/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Import
 description: >-
   OpenTF can import and manage existing infrastructure. This can help you
   transition your infrastructure to OpenTF.

--- a/website/docs/cli/import/usage.mdx
+++ b/website/docs/cli/import/usage.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Import: Usage'
 description: The `opentf import` command is used to import existing infrastructure.
 ---
 

--- a/website/docs/cli/index.mdx
+++ b/website/docs/cli/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: OpenTF CLI Documentation
+sidebar_position: 1
 description: >-
   Learn OpenTF's CLI-based workflows. You can use the CLI alone or
   with cloud backends.

--- a/website/docs/cli/init/index.mdx
+++ b/website/docs/cli/init/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Initializing Working Directories - OpenTF CLI
 description: >-
   Working directories contain configurations, settings, cached plugins and
   modules, and state data. Learn how to initialize and manage working

--- a/website/docs/cli/inspect/index.mdx
+++ b/website/docs/cli/inspect/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Inspecting Infrastructure - OpenTF CLI
 description: >-
   Learn commands to inspect dependency information, outputs, etc. Use them for
   integration or to understand your infrastructure.

--- a/website/docs/cli/install/_category_.json
+++ b/website/docs/cli/install/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Install"
+}

--- a/website/docs/cli/install/apt.mdx
+++ b/website/docs/cli/install/apt.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: APT Packages for Debian and Ubuntu
 description: >-
   The OpenTF APT repositories contain distribution-specific OpenTF
   packages for both Debian and Ubuntu systems.

--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: 'Yum Packages for Red Hat Enterprise Linux, Fedora, and Amazon Linux'
+title: Yum Packages for Red Hat Enterprise Linux, Fedora, and Amazon Linux
 description: >-
   The OpenTF Yum repositories contain distribution-specific OpenTF
   packages for Red Hat Enterprise Linux, Fedora, and Amazon Linux systems.

--- a/website/docs/cli/plugins/index.mdx
+++ b/website/docs/cli/plugins/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Managing Plugins - OpenTF CLI
 description: >-
   Commands to install, configure, and show information about providers. Also
   commands to reduce install effort in air-gapped environments.

--- a/website/docs/cli/plugins/signing.mdx
+++ b/website/docs/cli/plugins/signing.mdx
@@ -1,11 +1,10 @@
 ---
-page_title: Plugin Signing
 description: >-
   Learn about the types of signatures providers can have on the OpenTF
   Registry.
 ---
 
-{/* THIS PAGED IS LINKED TO IN THE CLI */}
+<!-- THIS PAGED IS LINKED TO IN THE CLI -->
 
 # Plugin Signing
 

--- a/website/docs/cli/run/index.mdx
+++ b/website/docs/cli/run/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provisioning Infrastructure - OpenTF CLI
 description: 'Learn about commands for core provisioning tasks: plan, apply, and destroy.'
 ---
 

--- a/website/docs/cli/state/index.mdx
+++ b/website/docs/cli/state/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Manipulating State - OpenTF CLI
 description: >-
   State data tracks which real-world object corresponds to each resource.
   Inspect state, move or import resources, and more.

--- a/website/docs/cli/state/inspect.mdx
+++ b/website/docs/cli/state/inspect.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Inspecting State - OpenTF CLI
 description: Commands that allow you to read and update state.
 ---
 

--- a/website/docs/cli/state/move.mdx
+++ b/website/docs/cli/state/move.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Moving Resources - OpenTF CLI
 description: >-
   Commands that allow you to manage the way that resources are tracked in state.
   They are helpful when you move or change resources.

--- a/website/docs/cli/state/recover.mdx
+++ b/website/docs/cli/state/recover.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Recovering from State Disasters - OpenTF CLI
 description: >-
   Learn how to restore state backups and override OpenTF state protections to fix state errors with the OpenTF CLI.
 

--- a/website/docs/cli/state/resource-addressing.mdx
+++ b/website/docs/cli/state/resource-addressing.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Internals: Resource Address'
 description: |-
   A resource address is a string that identifies zero or more resource
   instances in your overall configuration.

--- a/website/docs/cli/state/taint.mdx
+++ b/website/docs/cli/state/taint.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Forcing Re-creation of Resources - OpenTF CLI
 description: Commands that allow you to destroy and re-create resources manually.
 ---
 

--- a/website/docs/cli/workspaces/index.mdx
+++ b/website/docs/cli/workspaces/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Managing Workspaces - OpenTF CLI
 description: >-
   Commands to list, select, create, and output workspaces. Workspaces help
   manage different groups of resources with one configuration.

--- a/website/docs/internals/credentials-helpers.mdx
+++ b/website/docs/internals/credentials-helpers.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Credentials Helpers
 description: >-
   Credentials helpers are external programs that know how to store and retrieve
   API tokens for remote OpenTF services.

--- a/website/docs/internals/debugging.mdx
+++ b/website/docs/internals/debugging.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Debugging
 description: >-
   OpenTF has detailed logs which can be enabled by setting the TF_LOG
   environment variable to any value. This will cause detailed logs to appear on

--- a/website/docs/internals/functions-meta.mdx
+++ b/website/docs/internals/functions-meta.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Functions Metadata
 description: >-
   The `opentf metadata functions` command prints signatures for all the
   functions available in the current OpenTF version.

--- a/website/docs/internals/graph.mdx
+++ b/website/docs/internals/graph.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Resource Graph
 description: >-
   OpenTF builds a dependency graph from the OpenTF configurations, and
   walks this graph to generate plans, refresh state, and more. This page

--- a/website/docs/internals/index.mdx
+++ b/website/docs/internals/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Internals
+sidebar_position: 1
 description: >-
   Learn how OpenTF generates the resource dependency graph and executes other internal processes.
 ---

--- a/website/docs/internals/json-format.mdx
+++ b/website/docs/internals/json-format.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Internals: JSON Output Format'
 description: >-
   OpenTF provides a machine-readable JSON representation of state,
   configuration and plan.

--- a/website/docs/internals/login-protocol.mdx
+++ b/website/docs/internals/login-protocol.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Login Protocol
 description: >-
   The login protocol is used for authenticating OpenTF against servers
   providing OpenTF-native services.

--- a/website/docs/internals/machine-readable-ui.mdx
+++ b/website/docs/internals/machine-readable-ui.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Internals: Machine-Readable UI'
 description: >-
   OpenTF provides a machine-readable streaming JSON UI output for plan,
   apply, and refresh operations.

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Module Registry Protocol
 description: |-
   The module registry protocol is implemented by a host intending to be the
   host of one or more OpenTF modules, specifying which modules are available

--- a/website/docs/internals/provider-meta.mdx
+++ b/website/docs/internals/provider-meta.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provider Metadata
 description: >-
   For advanced use cases, modules can provide some pre-defined metadata for
   providers.

--- a/website/docs/internals/provider-network-mirror-protocol.mdx
+++ b/website/docs/internals/provider-network-mirror-protocol.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provider Network Mirror Protocol
 description: |-
   The provider network mirror protocol is implemented by a server intending
   to provide a mirror or read-through caching proxy for OpenTF providers,

--- a/website/docs/internals/provider-registry-protocol.mdx
+++ b/website/docs/internals/provider-registry-protocol.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provider Registry Protocol
 description: |-
   The provider registry protocol is implemented by a host intending to be the
   origin host for one or more OpenTF providers, specifying which providers

--- a/website/docs/internals/remote-service-discovery.mdx
+++ b/website/docs/internals/remote-service-discovery.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Internals: Remote Service Discovery'
 description: |-
   Remote service discovery is a protocol used to locate OpenTF-native
   services provided at a user-friendly hostname.

--- a/website/docs/intro/core-workflow.mdx
+++ b/website/docs/intro/core-workflow.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The Core OpenTF Workflow - Guides
 description: 'An overview of how individuals, teams, and organizations can use OpenTF. '
 ---
 

--- a/website/docs/intro/index.mdx
+++ b/website/docs/intro/index.mdx
@@ -1,7 +1,5 @@
 ---
-layout: "intro"
-page_title: "What is OpenTF"
-sidebar_current: "what"
+sidebar_position: 1
 description: |-
  OpenTF is an infrastructure as code tool that lets you build, change, and version cloud and on-prem resources safely and efficiently.
 ---

--- a/website/docs/intro/use-cases.mdx
+++ b/website/docs/intro/use-cases.mdx
@@ -1,7 +1,4 @@
 ---
-layout: "intro"
-page_title: "Use Cases"
-sidebar_current: "use-cases"
 description: |-
   Learn how OpenTF enables multi-cloud deployments, application management, policy compliance, and self-service infrastructure.
 ---

--- a/website/docs/intro/vs/boto.mdx
+++ b/website/docs/intro/vs/boto.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'OpenTF vs. Boto, Fog, etc.'
 description: 'How OpenTF compares to cloud provider client libraries like Boto and Fog. '
 ---
 

--- a/website/docs/intro/vs/chef-puppet.mdx
+++ b/website/docs/intro/vs/chef-puppet.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'OpenTF vs. Chef, Puppet, etc.'
 description: >-
   How OpenTF compares to configuration management tools like Chef and
   Puppet.

--- a/website/docs/intro/vs/cloudformation.mdx
+++ b/website/docs/intro/vs/cloudformation.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'OpenTF vs. CloudFormation, Heat, etc.'
 description: >-
   How OpenTF compares to other infrastructure as code tools like
   CloudFormation and Heat. OpenTF can simultaneously manage multiple cloud

--- a/website/docs/intro/vs/custom.mdx
+++ b/website/docs/intro/vs/custom.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: OpenTF vs. Custom Solutions
 description: >-
   Why OpenTF is easier to use and maintain than custom, internal
   infrastructure solutions.

--- a/website/docs/intro/vs/index.mdx
+++ b/website/docs/intro/vs/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: OpenTF vs. Alternatives
 description: An overview of how OpenTF compares to alternative software and tools.
 ---
 

--- a/website/docs/language/attr-as-blocks.mdx
+++ b/website/docs/language/attr-as-blocks.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Attributes as Blocks - Configuration Language
 description: >-
   For historical reasons, certain arguments within resource blocks can use
   either

--- a/website/docs/language/checks/index.mdx
+++ b/website/docs/language/checks/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Checks - Configuration Language
 description: >-
   Check customized infrastructure requirements to provide ongoing and continuous verification.
 ---

--- a/website/docs/language/data-sources/index.mdx
+++ b/website/docs/language/data-sources/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Data Sources - Configuration Language
 description: >-
   Data sources allow OpenTF to use external data, function output, and data
   from other configurations. Learn data resource arguments, behavior, and

--- a/website/docs/language/expressions/conditionals.mdx
+++ b/website/docs/language/expressions/conditionals.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Conditional Expressions - Configuration Language
 description: >-
   Conditional expressions select one of two values. You can use them to define
   defaults to replace invalid values.

--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Custom Conditions - Configuration Language
 description: >-
   Check custom requirements for variables, outputs, data sources, and resources and provide better error messages in context.
 ---

--- a/website/docs/language/expressions/dynamic-blocks.mdx
+++ b/website/docs/language/expressions/dynamic-blocks.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Dynamic Blocks - Configuration Language
+title: Dynamic Blocks
 description: >-
   Dynamic blocks automatically construct multi-level, nested block structures.
   Learn to configure dynamic blocks and understand their behavior.

--- a/website/docs/language/expressions/for.mdx
+++ b/website/docs/language/expressions/for.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: For Expressions - Configuration Language
+title: For Expressions
 description: >-
   For expressions transform complex input values into complex output values.
   Learn how to filter inputs and how to group results.

--- a/website/docs/language/expressions/function-calls.mdx
+++ b/website/docs/language/expressions/function-calls.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Function Calls - Configuration Language
 description: >-
   Functions transform and combine values. Learn about OpenTF's built-in
   functions.

--- a/website/docs/language/expressions/index.mdx
+++ b/website/docs/language/expressions/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Expressions - Configuration Language
 description: >-
   An overview of expressions to reference or compute values in OpenTF
   configurations, including types, operators, and functions.

--- a/website/docs/language/expressions/operators.mdx
+++ b/website/docs/language/expressions/operators.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Operators - Configuration Language
 description: >-
   Operators transform or combine expressions. Learn about arithmetic, logical,
   equality, and comparison operators.

--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: References to Values - Configuration Language
 description: >-
   Reference values in configurations, including resources, input variables,
   local and block-local values, module outputs, data sources, and workspace

--- a/website/docs/language/expressions/splat.mdx
+++ b/website/docs/language/expressions/splat.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Splat Expressions - Configuration Language
 description: >-
   Splat expressions concisely represent common operations. In Terraform, they
   also transform single, non-null values into a single-element tuple.

--- a/website/docs/language/expressions/strings.mdx
+++ b/website/docs/language/expressions/strings.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Strings and Templates - Configuration Language
 description: >-
   String literals and template sequences interpolate values and manipulate text.
   Learn about both quoted and heredoc string syntax.

--- a/website/docs/language/expressions/type-constraints.mdx
+++ b/website/docs/language/expressions/type-constraints.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Type Constraints - Configuration Language
 description: >-
   Learn how to use type constraints to validate user inputs to modules and
   resources.

--- a/website/docs/language/expressions/types.mdx
+++ b/website/docs/language/expressions/types.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Types and Values - Configuration Language
 description: >-
   Learn about value types and syntax, including string, number, bool, list, and
   map. Also learn about complex types and type conversion.

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Version Constraints - Configuration Language
 description: >-
   Version constraint strings specify a range of acceptable versions for modules,
   providers, and OpenTF itself. Learn version constraint syntax and behavior.

--- a/website/docs/language/files/dependency-lock.mdx
+++ b/website/docs/language/files/dependency-lock.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Dependency Lock File (.terraform.lock.hcl) - Configuration Language
+title: Dependency Lock File
 description: >-
   OpenTF uses the dependency lock file .teraform.lock.hcl to track and select
   provider versions. Learn about dependency installation and lock file changes.

--- a/website/docs/language/files/index.mdx
+++ b/website/docs/language/files/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Files and Directories - Configuration Language
 description: >-
   Learn how to name, organize, and store OpenTF configuration files. Also
   learn how OpenTF evaluates modules.

--- a/website/docs/language/files/override.mdx
+++ b/website/docs/language/files/override.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Override Files - Configuration Language
 description: >-
   Override files merge additional settings into existing configuration objects.
   Learn how to use override files and about merging behavior.

--- a/website/docs/language/functions/abs.mdx
+++ b/website/docs/language/functions/abs.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: abs - Functions - Configuration Language
+sidebar_label: abs
 description: The abs function returns the absolute value of the given number.
 ---
 

--- a/website/docs/language/functions/abspath.mdx
+++ b/website/docs/language/functions/abspath.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: abspath - Functions - Configuration Language
+sidebar_label: abspath
 description: The abspath function converts the argument to an absolute filesystem path.
 ---
 

--- a/website/docs/language/functions/alltrue.mdx
+++ b/website/docs/language/functions/alltrue.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: alltrue - Functions - Configuration Language
+sidebar_label: alltrue
 description: |-
   The alltrue function determines whether all elements of a collection
   are true or "true". If the collection is empty, it returns true.

--- a/website/docs/language/functions/anytrue.mdx
+++ b/website/docs/language/functions/anytrue.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: anytrue - Functions - Configuration Language
+sidebar_label: anytrue
 description: |-
   The anytrue function determines whether any element of a collection
   is true or "true". If the collection is empty, it returns false.

--- a/website/docs/language/functions/base64decode.mdx
+++ b/website/docs/language/functions/base64decode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: base64decode - Functions - Configuration Language
+sidebar_label: base64decode
 description: The base64decode function decodes a string containing a base64 sequence.
 ---
 

--- a/website/docs/language/functions/base64encode.mdx
+++ b/website/docs/language/functions/base64encode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: base64encode - Functions - Configuration Language
+sidebar_label: base64encode
 description: The base64encode function applies Base64 encoding to a string.
 ---
 

--- a/website/docs/language/functions/base64gzip.mdx
+++ b/website/docs/language/functions/base64gzip.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: base64gzip - Functions - Configuration Language
+sidebar_label: base64gzip
 description: |-
   The base64encode function compresses the given string with gzip and then
   encodes the result in Base64.

--- a/website/docs/language/functions/base64sha256.mdx
+++ b/website/docs/language/functions/base64sha256.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: base64sha256 - Functions - Configuration Language
+sidebar_label: base64sha256
 description: |-
   The base64sha256 function computes the SHA256 hash of a given string and
   encodes it with Base64.

--- a/website/docs/language/functions/base64sha512.mdx
+++ b/website/docs/language/functions/base64sha512.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: base64sha512 - Functions - Configuration Language
+sidebar_label: base64sha512
 description: |-
   The base64sha512 function computes the SHA512 hash of a given string and
   encodes it with Base64.

--- a/website/docs/language/functions/basename.mdx
+++ b/website/docs/language/functions/basename.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: basename - Functions - Configuration Language
+sidebar_label: basename
 description: |-
   The basename function removes all except the last portion from a filesystem
   path.

--- a/website/docs/language/functions/bcrypt.mdx
+++ b/website/docs/language/functions/bcrypt.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: bcrypt - Functions - Configuration Language
+sidebar_label: bcrypt
 description: |-
   The bcrypt function computes a hash of the given string using the Blowfish
   cipher.

--- a/website/docs/language/functions/can.mdx
+++ b/website/docs/language/functions/can.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: can - Functions - Configuration Language
+sidebar_label: can
 description: |-
   The can function tries to evaluate an expression given as an argument and
   indicates whether the evaluation succeeded.

--- a/website/docs/language/functions/ceil.mdx
+++ b/website/docs/language/functions/ceil.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: ceil - Functions - Configuration Language
+sidebar_label: ceil
 description: |-
   The ceil function returns the closest whole number greater than or equal to
   the given value.

--- a/website/docs/language/functions/chomp.mdx
+++ b/website/docs/language/functions/chomp.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: chomp - Functions - Configuration Language
+sidebar_label: chomp
 description: The chomp function removes newline characters at the end of a string.
 ---
 

--- a/website/docs/language/functions/chunklist.mdx
+++ b/website/docs/language/functions/chunklist.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: chunklist - Functions - Configuration Language
+sidebar_label: chunklist
 description: |-
   The chunklist function splits a single list into fixed-size chunks, returning
   a list of lists.

--- a/website/docs/language/functions/cidrhost.mdx
+++ b/website/docs/language/functions/cidrhost.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: cidrhost - Functions - Configuration Language
+sidebar_label: cidrhost
 description: |-
   The cidrhost function calculates a full host IP address within a given
   IP network address prefix.

--- a/website/docs/language/functions/cidrnetmask.mdx
+++ b/website/docs/language/functions/cidrnetmask.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: cidrnetmask - Functions - Configuration Language
+sidebar_label: cidrnetmask
 description: |-
   The cidrnetmask function converts an IPv4 address prefix given in CIDR
   notation into a subnet mask address.

--- a/website/docs/language/functions/cidrsubnet.mdx
+++ b/website/docs/language/functions/cidrsubnet.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: cidrsubnet - Functions - Configuration Language
+sidebar_label: cidrsubnet
 description: |-
   The cidrsubnet function calculates a subnet address within a given IP network
   address prefix.

--- a/website/docs/language/functions/cidrsubnets.mdx
+++ b/website/docs/language/functions/cidrsubnets.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: cidrsubnets - Functions - Configuration Language
+sidebar_label: cidrsubnets
 description: |-
   The cidrsubnets function calculates a sequence of consecutive IP address
   ranges within a particular CIDR prefix.

--- a/website/docs/language/functions/coalesce.mdx
+++ b/website/docs/language/functions/coalesce.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: coalesce - Functions - Configuration Language
+sidebar_label: coalesce
 description: |-
   The coalesce function takes any number of arguments and returns the
   first one that isn't null nor empty.

--- a/website/docs/language/functions/coalescelist.mdx
+++ b/website/docs/language/functions/coalescelist.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: coalescelist - Functions - Configuration Language
+sidebar_label: coalescelist
 description: |-
   The coalescelist function takes any number of list arguments and returns the
   first one that isn't empty.

--- a/website/docs/language/functions/compact.mdx
+++ b/website/docs/language/functions/compact.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: compact - Functions - Configuration Language
+sidebar_label: compact
 description: The compact function removes null or empty string elements from a list.
 ---
 

--- a/website/docs/language/functions/concat.mdx
+++ b/website/docs/language/functions/concat.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: concat - Functions - Configuration Language
+sidebar_label: concat
 description: The concat function combines two or more lists into a single list.
 ---
 

--- a/website/docs/language/functions/contains.mdx
+++ b/website/docs/language/functions/contains.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: contains - Functions - Configuration Language
+sidebar_label: contains
 description: The contains function determines whether a list or set contains a given value.
 ---
 

--- a/website/docs/language/functions/csvdecode.mdx
+++ b/website/docs/language/functions/csvdecode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: csvdecode - Functions - Configuration Language
+sidebar_label: csvdecode
 description: The csvdecode function decodes CSV data into a list of maps.
 ---
 

--- a/website/docs/language/functions/dirname.mdx
+++ b/website/docs/language/functions/dirname.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: dirname - Functions - Configuration Language
+sidebar_label: dirname
 description: The dirname function removes the last portion from a filesystem path.
 ---
 

--- a/website/docs/language/functions/distinct.mdx
+++ b/website/docs/language/functions/distinct.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: distinct - Functions - Configuration Language
+sidebar_label: distinct
 description: The distinct function removes duplicate elements from a list.
 ---
 

--- a/website/docs/language/functions/element.mdx
+++ b/website/docs/language/functions/element.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: element - Functions - Configuration Language
+sidebar_label: element
 description: The element function retrieves a single element from a list.
 ---
 

--- a/website/docs/language/functions/endswith.mdx
+++ b/website/docs/language/functions/endswith.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: endswith - Functions - Configuration Language
+sidebar_label: endswith
 description: |-
   The endswith function takes two values: a string to check and a suffix string. It returns true if the first string ends with that exact suffix.
 ---

--- a/website/docs/language/functions/file.mdx
+++ b/website/docs/language/functions/file.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: file - Functions - Configuration Language
+sidebar_label: file
 description: |-
   The file function reads the contents of the file at the given path and
   returns them as a string.

--- a/website/docs/language/functions/filebase64.mdx
+++ b/website/docs/language/functions/filebase64.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filebase64 - Functions - Configuration Language
+sidebar_label: filebase64
 description: |-
   The filebase64 function reads the contents of the file at the given path and
   returns them as a base64-encoded string.

--- a/website/docs/language/functions/filebase64sha256.mdx
+++ b/website/docs/language/functions/filebase64sha256.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filebase64sha256 - Functions - Configuration Language
+sidebar_label: filebase64sha256
 description: |-
   The filebase64sha256 function computes the SHA256 hash of the contents of
   a given file and encodes it with Base64.

--- a/website/docs/language/functions/filebase64sha512.mdx
+++ b/website/docs/language/functions/filebase64sha512.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filebase64sha512 - Functions - Configuration Language
+sidebar_label: filebase64sha512
 description: |-
   The filebase64sha512 function computes the SHA512 hash of the contents of
   a given file and encodes it with Base64.

--- a/website/docs/language/functions/fileexists.mdx
+++ b/website/docs/language/functions/fileexists.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: fileexists - Functions - Configuration Language
+sidebar_label: fileexists
 description: The fileexists function determines whether a file exists at a given path.
 ---
 

--- a/website/docs/language/functions/filemd5.mdx
+++ b/website/docs/language/functions/filemd5.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filemd5 - Functions - Configuration Language
+sidebar_label: filemd5
 description: |-
   The filemd5 function computes the MD5 hash of the contents of
   a given file and encodes it as hex.

--- a/website/docs/language/functions/fileset.mdx
+++ b/website/docs/language/functions/fileset.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: fileset - Functions - Configuration Language
+sidebar_label: fileset
 description: The fileset function enumerates a set of regular file names given a pattern.
 ---
 

--- a/website/docs/language/functions/filesha1.mdx
+++ b/website/docs/language/functions/filesha1.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filesha1 - Functions - Configuration Language
+sidebar_label: filesha1
 description: |-
   The filesha1 function computes the SHA1 hash of the contents of
   a given file and encodes it as hex.

--- a/website/docs/language/functions/filesha256.mdx
+++ b/website/docs/language/functions/filesha256.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filesha256 - Functions - Configuration Language
+sidebar_label: filesha256
 description: |-
   The filesha256 function computes the SHA256 hash of the contents of
   a given file and encodes it as hex.

--- a/website/docs/language/functions/filesha512.mdx
+++ b/website/docs/language/functions/filesha512.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: filesha512 - Functions - Configuration Language
+sidebar_label: filesha512
 description: |-
   The filesha512 function computes the SHA512 hash of the contents of
   a given file and encodes it as hex.

--- a/website/docs/language/functions/flatten.mdx
+++ b/website/docs/language/functions/flatten.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: flatten - Functions - Configuration Language
+sidebar_label: flatten
 description: The flatten function eliminates nested lists from a list.
 ---
 

--- a/website/docs/language/functions/floor.mdx
+++ b/website/docs/language/functions/floor.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: floor - Functions - Configuration Language
+sidebar_label: floor
 description: |-
   The floor function returns the closest whole number less than or equal to
   the given value.

--- a/website/docs/language/functions/format.mdx
+++ b/website/docs/language/functions/format.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: format - Functions - Configuration Language
+sidebar_label: format
 description: |-
   The format function produces a string by formatting a number of other values
   according to a specification string.

--- a/website/docs/language/functions/formatdate.mdx
+++ b/website/docs/language/functions/formatdate.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: formatdate - Functions - Configuration Language
+sidebar_label: formatdate
 description: The formatdate function converts a timestamp into a different time format.
 ---
 

--- a/website/docs/language/functions/formatlist.mdx
+++ b/website/docs/language/functions/formatlist.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: formatlist - Functions - Configuration Language
+sidebar_label: formatlist
 description: |-
   The formatlist function produces a list of strings by formatting a number of
   other values according to a specification string.

--- a/website/docs/language/functions/indent.mdx
+++ b/website/docs/language/functions/indent.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: indent - Functions - Configuration Language
+sidebar_label: indent
 description: |-
   The indent function adds a number of spaces to the beginnings of all but the
   first line of a given multi-line string.

--- a/website/docs/language/functions/index.mdx
+++ b/website/docs/language/functions/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Functions - Configuration Language
 description: >-
   An introduction to the built-in functions that you can use to transform and
   combine values in expressions.

--- a/website/docs/language/functions/index_function.mdx
+++ b/website/docs/language/functions/index_function.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: index - Functions - Configuration Language
+sidebar_label: index
 description: The index function finds the element index for a given value in a list.
 ---
 

--- a/website/docs/language/functions/join.mdx
+++ b/website/docs/language/functions/join.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: join - Functions - Configuration Language
+sidebar_label: join
 description: |-
   The join function produces a string by concatenating the elements of a list
   with a given delimiter.

--- a/website/docs/language/functions/jsondecode.mdx
+++ b/website/docs/language/functions/jsondecode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: jsondecode - Functions - Configuration Language
+sidebar_label: jsondecode
 description: |-
   The jsondecode function decodes a JSON string into a representation of its
   value.

--- a/website/docs/language/functions/jsonencode.mdx
+++ b/website/docs/language/functions/jsonencode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: jsonencode - Functions - Configuration Language
+sidebar_label: jsonencode
 description: The jsonencode function encodes a given value as a JSON string.
 ---
 

--- a/website/docs/language/functions/keys.mdx
+++ b/website/docs/language/functions/keys.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: keys - Functions - Configuration Language
+sidebar_label: keys
 description: The keys function returns a list of the keys in a given map.
 ---
 

--- a/website/docs/language/functions/length.mdx
+++ b/website/docs/language/functions/length.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: length - Functions - Configuration Language
+sidebar_label: length
 description: The length function determines the length of a collection or string.
 ---
 

--- a/website/docs/language/functions/log.mdx
+++ b/website/docs/language/functions/log.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: log - Functions - Configuration Language
+sidebar_label: log
 description: The log function returns the logarithm of a given number in a given base.
 ---
 

--- a/website/docs/language/functions/lookup.mdx
+++ b/website/docs/language/functions/lookup.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: lookup - Functions - Configuration Language
+sidebar_label: lookup
 description: The lookup function retrieves an element value from a map given its key.
 ---
 

--- a/website/docs/language/functions/lower.mdx
+++ b/website/docs/language/functions/lower.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: lower - Functions - Configuration Language
+sidebar_label: lower
 description: >-
   The lower function converts all cased letters in the given string to
   lowercase.

--- a/website/docs/language/functions/matchkeys.mdx
+++ b/website/docs/language/functions/matchkeys.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: matchkeys - Functions - Configuration Language
+sidebar_label: matchkeys
 description: |-
   The matchkeys function takes a subset of elements from one list by matching
   corresponding indexes in another list.

--- a/website/docs/language/functions/max.mdx
+++ b/website/docs/language/functions/max.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: max - Functions - Configuration Language
+sidebar_label: max
 description: The max function takes one or more numbers and returns the greatest number.
 ---
 

--- a/website/docs/language/functions/md5.mdx
+++ b/website/docs/language/functions/md5.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: md5 - Functions - Configuration Language
+sidebar_label: md5
 description: |-
   The md5 function computes the MD5 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/docs/language/functions/merge.mdx
+++ b/website/docs/language/functions/merge.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: merge - Functions - Configuration Language
+sidebar_label: merge
 description: |-
   The merge function takes an arbitrary number maps or objects, and returns a
   single map or object that contains a merged set of elements from all

--- a/website/docs/language/functions/min.mdx
+++ b/website/docs/language/functions/min.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: min - Functions - Configuration Language
+sidebar_label: min
 description: The min function takes one or more numbers and returns the smallest number.
 ---
 

--- a/website/docs/language/functions/nonsensitive.mdx
+++ b/website/docs/language/functions/nonsensitive.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: nonsensitive - Functions - Configuration Language
+sidebar_label: nonsensitive
 description: >-
   The nonsensitive function removes the sensitive marking from a value that
   OpenTF considers to be sensitive.

--- a/website/docs/language/functions/one.mdx
+++ b/website/docs/language/functions/one.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: one - Functions - Configuration Language
+sidebar_label: one
 description: |-
   The 'one' function transforms a list with either zero or one elements into
   either a null value or the value of the first element.

--- a/website/docs/language/functions/parseint.mdx
+++ b/website/docs/language/functions/parseint.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: parseint - Functions - Configuration Language
+sidebar_label: parseint
 description: >-
   The parseint function parses the given string as a representation of an
   integer.

--- a/website/docs/language/functions/pathexpand.mdx
+++ b/website/docs/language/functions/pathexpand.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: pathexpand - Functions - Configuration Language
+sidebar_label: pathexpand
 description: |-
   The pathexpand function expands a leading ~ character to the current user's
   home directory.

--- a/website/docs/language/functions/plantimestamp.mdx
+++ b/website/docs/language/functions/plantimestamp.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: plantimestamp - Functions - Configuration Language
+sidebar_label: plantimestamp
 description: |-
   The plantimestamp functions a string representation of the date and time
   during the plan.

--- a/website/docs/language/functions/pow.mdx
+++ b/website/docs/language/functions/pow.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: pow - Functions - Configuration Language
+sidebar_label: pow
 description: The pow function raises a number to a power.
 ---
 

--- a/website/docs/language/functions/range.mdx
+++ b/website/docs/language/functions/range.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: range - Functions - Configuration Language
+sidebar_label: range
 description: The range function generates sequences of numbers.
 ---
 

--- a/website/docs/language/functions/regex.mdx
+++ b/website/docs/language/functions/regex.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: regex - Functions - Configuration Language
+sidebar_label: regex
 description: |-
   The regex function applies a regular expression to a string and returns the
   matching substrings.

--- a/website/docs/language/functions/regexall.mdx
+++ b/website/docs/language/functions/regexall.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: regexall - Functions - Configuration Language
+sidebar_label: regexall
 description: >-
   The regex function applies a regular expression to a string and returns a list
   of all matches.

--- a/website/docs/language/functions/replace.mdx
+++ b/website/docs/language/functions/replace.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: replace - Functions - Configuration Language
+sidebar_label: replace
 description: |-
   The replace function searches a given string for another given substring,
   and replaces all occurrences with a given replacement string.

--- a/website/docs/language/functions/reverse.mdx
+++ b/website/docs/language/functions/reverse.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: reverse - Functions - Configuration Language
+sidebar_label: reverse
 description: The reverse function reverses a sequence.
 ---
 

--- a/website/docs/language/functions/rsadecrypt.mdx
+++ b/website/docs/language/functions/rsadecrypt.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: rsadecrypt - Functions - Configuration Language
+sidebar_label: rsadecrypt
 description: The rsadecrypt function decrypts an RSA-encrypted message.
 ---
 

--- a/website/docs/language/functions/sensitive.mdx
+++ b/website/docs/language/functions/sensitive.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: sensitive - Functions - Configuration Language
+sidebar_label: sensitive
 description: The sensitive function marks a value as being sensitive.
 ---
 

--- a/website/docs/language/functions/setintersection.mdx
+++ b/website/docs/language/functions/setintersection.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: setintersection - Functions - Configuration Language
+sidebar_label: setintersection
 description: |-
   The setintersection function takes multiple sets and produces a single set
   containing only the elements that all of the given sets have in common.

--- a/website/docs/language/functions/setproduct.mdx
+++ b/website/docs/language/functions/setproduct.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: setproduct - Functions - Configuration Language
+sidebar_label: setproduct
 description: |-
   The setproduct function finds all of the possible combinations of elements
   from all of the given sets by computing the cartesian product.

--- a/website/docs/language/functions/setsubtract.mdx
+++ b/website/docs/language/functions/setsubtract.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: setsubtract - Functions - Configuration Language
+sidebar_label: setsubtract
 description: |-
   The setsubtract function returns a new set containing the elements
   from the first set that are not present in the second set

--- a/website/docs/language/functions/setunion.mdx
+++ b/website/docs/language/functions/setunion.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: setunion - Functions - Configuration Language
+sidebar_label: setunion
 description: |-
   The setunion function takes multiple sets and produces a single set
   containing the elements from all of the given sets.

--- a/website/docs/language/functions/sha1.mdx
+++ b/website/docs/language/functions/sha1.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: sha1 - Functions - Configuration Language
+sidebar_label: sha1
 description: |-
   The sha1 function computes the SHA1 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/docs/language/functions/sha256.mdx
+++ b/website/docs/language/functions/sha256.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: sha256 - Functions - Configuration Language
+sidebar_label: sha256
 description: |-
   The sha256 function computes the SHA256 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/docs/language/functions/sha512.mdx
+++ b/website/docs/language/functions/sha512.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: sha512 - Functions - Configuration Language
+sidebar_label: sha512
 description: |-
   The sha512 function computes the SHA512 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/docs/language/functions/signum.mdx
+++ b/website/docs/language/functions/signum.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: signum - Functions - Configuration Language
+sidebar_label: signum
 description: The signum function determines the sign of a number.
 ---
 

--- a/website/docs/language/functions/slice.mdx
+++ b/website/docs/language/functions/slice.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: slice - Functions - Configuration Language
+sidebar_label: slice
 description: The slice function extracts some consecutive elements from within a list.
 ---
 

--- a/website/docs/language/functions/sort.mdx
+++ b/website/docs/language/functions/sort.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: sort - Functions - Configuration Language
+sidebar_label: sort
 description: |-
   The sort function takes a list of strings and returns a new list with those
   strings sorted lexicographically.

--- a/website/docs/language/functions/split.mdx
+++ b/website/docs/language/functions/split.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: split - Functions - Configuration Language
+sidebar_label: split
 description: |-
   The split function produces a list by dividing a given string at all
   occurrences of a given separator.

--- a/website/docs/language/functions/startswith.mdx
+++ b/website/docs/language/functions/startswith.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: startswith - Functions - Configuration Language
+sidebar_label: startswith
 description: |-
   The startswith function  takes two values: a string to check and a prefix string. It returns true if the string begins with that exact prefix.
 ---

--- a/website/docs/language/functions/strcontains.mdx
+++ b/website/docs/language/functions/strcontains.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: strcontains - Functions - Configuration Language
+sidebar_label: strcontains
 description: |-
   The strcontains function checks whether a given string can be found within another string.
 ---

--- a/website/docs/language/functions/strrev.mdx
+++ b/website/docs/language/functions/strrev.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: strrev - Functions - Configuration Language
+sidebar_label: strrev
 description: The strrev function reverses a string.
 ---
 

--- a/website/docs/language/functions/substr.mdx
+++ b/website/docs/language/functions/substr.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: substr - Functions - Configuration Language
+sidebar_label: substr
 description: |-
   The substr function extracts a substring from a given string by offset and
   length.

--- a/website/docs/language/functions/sum.mdx
+++ b/website/docs/language/functions/sum.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: sum - Functions - Configuration Language
+sidebar_label: sum
 description: |-
   The sum function takes a list or set of numbers and returns the sum of those
   numbers.

--- a/website/docs/language/functions/templatefile.mdx
+++ b/website/docs/language/functions/templatefile.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: templatefile - Functions - Configuration Language
+sidebar_label: templatefile
 description: |-
   The templatefile function reads the file at the given path and renders its
   content as a template.

--- a/website/docs/language/functions/textdecodebase64.mdx
+++ b/website/docs/language/functions/textdecodebase64.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: textdecodebase64 - Functions - Configuration Language
+sidebar_label: textdecodebase64
 description: >-
   The textdecodebase64 function decodes a string that was previously
   Base64-encoded,

--- a/website/docs/language/functions/textencodebase64.mdx
+++ b/website/docs/language/functions/textencodebase64.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: textencodebase64 - Functions - Configuration Language
+sidebar_label: textencodebase64
 description: >-
   The textencodebase64 function encodes the unicode characters in a given string
   using a

--- a/website/docs/language/functions/timeadd.mdx
+++ b/website/docs/language/functions/timeadd.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: timeadd - Functions - Configuration Language
+sidebar_label: timeadd
 description: |-
   The timeadd function adds a duration to a timestamp, returning a new
   timestamp.

--- a/website/docs/language/functions/timecmp.mdx
+++ b/website/docs/language/functions/timecmp.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: timecmp - Functions - Configuration Language
+sidebar_label: timecmp
 description: |-
   The timecmp function adds a duration to a timestamp, returning a new
   timestamp.

--- a/website/docs/language/functions/timestamp.mdx
+++ b/website/docs/language/functions/timestamp.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: timestamp - Functions - Configuration Language
+sidebar_label: timestamp
 description: |-
   The timestamp function returns a string representation of the current date
   and time.

--- a/website/docs/language/functions/title.mdx
+++ b/website/docs/language/functions/title.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: title - Functions - Configuration Language
+sidebar_label: title
 description: |-
   The title function converts the first letter of each word in a given string
   to uppercase.

--- a/website/docs/language/functions/tobool.mdx
+++ b/website/docs/language/functions/tobool.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tobool - Functions - Configuration Language
+sidebar_label: tobool
 description: The tobool function converts a value to boolean.
 ---
 

--- a/website/docs/language/functions/tolist.mdx
+++ b/website/docs/language/functions/tolist.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tolist - Functions - Configuration Language
+sidebar_label: tolist
 description: The tolist function converts a value to a list.
 ---
 

--- a/website/docs/language/functions/tomap.mdx
+++ b/website/docs/language/functions/tomap.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tomap - Functions - Configuration Language
+sidebar_label: tomap
 description: The tomap function converts a value to a map.
 ---
 

--- a/website/docs/language/functions/tonumber.mdx
+++ b/website/docs/language/functions/tonumber.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tonumber - Functions - Configuration Language
+sidebar_label: tonumber
 description: The tonumber function converts a value to a number.
 ---
 

--- a/website/docs/language/functions/toset.mdx
+++ b/website/docs/language/functions/toset.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: toset - Functions - Configuration Language
+sidebar_label: toset
 description: The toset function converts a value to a set.
 ---
 

--- a/website/docs/language/functions/tostring.mdx
+++ b/website/docs/language/functions/tostring.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tostring - Functions - Configuration Language
+sidebar_label: tostring
 description: The tostring function converts a value to a string.
 ---
 

--- a/website/docs/language/functions/transpose.mdx
+++ b/website/docs/language/functions/transpose.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: transpose - Functions - Configuration Language
+sidebar_label: transpose
 description: |-
   The transpose function takes a map of lists of strings and swaps the keys
   and values.

--- a/website/docs/language/functions/trim.mdx
+++ b/website/docs/language/functions/trim.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: trim - Functions - Configuration Language
+sidebar_label: trim
 description: >-
   The trim function removes the specified set of characters from the start and
   end of

--- a/website/docs/language/functions/trimprefix.mdx
+++ b/website/docs/language/functions/trimprefix.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: trimprefix - Functions - Configuration Language
+sidebar_label: trimprefix
 description: |-
   The trimprefix function removes the specified prefix from the start of a
   given string.

--- a/website/docs/language/functions/trimspace.mdx
+++ b/website/docs/language/functions/trimspace.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: trimspace - Functions - Configuration Language
+sidebar_label: trimspace
 description: |-
   The trimspace function removes space characters from the start and end of
   a given string.

--- a/website/docs/language/functions/trimsuffix.mdx
+++ b/website/docs/language/functions/trimsuffix.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: trimsuffix - Functions - Configuration Language
+sidebar_label: trimsuffix
 description: |-
   The trimsuffix function removes the specified suffix from the end of a
   given string.

--- a/website/docs/language/functions/try.mdx
+++ b/website/docs/language/functions/try.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: try - Functions - Configuration Language
+sidebar_label: try
 description: |-
   The try function tries to evaluate a sequence of expressions given as
   arguments and returns the result of the first one that does not produce

--- a/website/docs/language/functions/type.mdx
+++ b/website/docs/language/functions/type.mdx
@@ -1,6 +1,6 @@
 ---
-page_title: type - Functions - Configuration Language
-description: 'The type function returns the type of a given value. '
+sidebar_label: type
+description: "The type function returns the type of a given value. "
 ---
 
 # `type` Function

--- a/website/docs/language/functions/upper.mdx
+++ b/website/docs/language/functions/upper.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: upper - Functions - Configuration Language
+sidebar_label: upper
 description: >-
   The upper function converts all cased letters in the given string to
   uppercase.

--- a/website/docs/language/functions/urlencode.mdx
+++ b/website/docs/language/functions/urlencode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: urlencode - Functions - Configuration Language
+sidebar_label: urlencode
 description: The urlencode function applies URL encoding to a given string.
 ---
 

--- a/website/docs/language/functions/uuid.mdx
+++ b/website/docs/language/functions/uuid.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: uuid - Functions - Configuration Language
+sidebar_label: uuid
 description: The uuid function generates a unique id.
 ---
 

--- a/website/docs/language/functions/uuidv5.mdx
+++ b/website/docs/language/functions/uuidv5.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: uuidv5 - Functions - Configuration Language
+sidebar_label: uuidv5
 description: >-
   The uuidv5 function generates a uuid v5 string representation of the value in
   the specified namespace.

--- a/website/docs/language/functions/values.mdx
+++ b/website/docs/language/functions/values.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: values - Functions - Configuration Language
+sidebar_label: values
 description: The values function returns a list of the element values in a given map.
 ---
 

--- a/website/docs/language/functions/yamldecode.mdx
+++ b/website/docs/language/functions/yamldecode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: yamldecode - Functions - Configuration Language
+sidebar_label: yamldecode
 description: |-
   The yamldecode function decodes a YAML string into a representation of its
   value.

--- a/website/docs/language/functions/yamlencode.mdx
+++ b/website/docs/language/functions/yamlencode.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: yamlencode - Functions - Configuration Language
+sidebar_label: yamlencode
 description: The yamlencode function encodes a given value as a YAML string.
 ---
 

--- a/website/docs/language/functions/zipmap.mdx
+++ b/website/docs/language/functions/zipmap.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: zipmap - Functions - Configuration Language
+sidebar_label: zipmap
 description: |-
   The zipmap function constructs a map from a list of keys and a corresponding
   list of values.

--- a/website/docs/language/import/generating-configuration.mdx
+++ b/website/docs/language/import/generating-configuration.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Import - Generating Configuration
 description: >-
   Generate configuration and manage existing resources with OpenTF using configuration-driven import.
 ---

--- a/website/docs/language/import/index.mdx
+++ b/website/docs/language/import/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Import - Configuration Language
 description: >-
   Import and manage existing resources with OpenTF using configuration-driven import.
 ---

--- a/website/docs/language/index.mdx
+++ b/website/docs/language/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Overview - Configuration Language
+sidebar_position: 1
 description: >-
   Use the OpenTF configuration language to describe the infrastructure that OpenTF manages.
 ---

--- a/website/docs/language/meta-arguments/_category_.json
+++ b/website/docs/language/meta-arguments/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Meta-Arguments"
+}

--- a/website/docs/language/meta-arguments/count.mdx
+++ b/website/docs/language/meta-arguments/count.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The count Meta-Argument - Configuration Language
 description: >-
   Count helps you efficiently manage nearly identical infrastructure resources
   without writing a separate block for each one.

--- a/website/docs/language/meta-arguments/depends_on.mdx
+++ b/website/docs/language/meta-arguments/depends_on.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The depends_on Meta-Argument - Configuration Language
 description: >-
   The depends_on meta-argument allows you to handle hidden resource or module
   dependencies.

--- a/website/docs/language/meta-arguments/for_each.mdx
+++ b/website/docs/language/meta-arguments/for_each.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The for_each Meta-Argument - Configuration Language
 description: >-
   The for_each meta-argument allows you to manage similar infrastructure
   resources without writing a separate block for each one.

--- a/website/docs/language/meta-arguments/lifecycle.mdx
+++ b/website/docs/language/meta-arguments/lifecycle.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The lifecycle Meta-Argument - Configuration Language
 description: >-
   The meta-arguments in a lifecycle block allow you to customize resource
   behavior.

--- a/website/docs/language/meta-arguments/module-providers.mdx
+++ b/website/docs/language/meta-arguments/module-providers.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The Module providers Meta-Argument - Configuration Language
 description: >-
   The providers meta-argument specifies which provider configurations from a
   parent module are available in a child module.

--- a/website/docs/language/meta-arguments/resource-provider.mdx
+++ b/website/docs/language/meta-arguments/resource-provider.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The Resource provider Meta-Argument - Configuration Language
 description: >-
   The provider meta-argument specifies the provider configuration OpenTF
   should use for a resource, overriding OpenTF's default behavior.

--- a/website/docs/language/modules/develop/composition.mdx
+++ b/website/docs/language/modules/develop/composition.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Module Composition
 description: |-
   Module composition allows infrastructure to be described from modular
   building blocks.

--- a/website/docs/language/modules/develop/index.mdx
+++ b/website/docs/language/modules/develop/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Creating Modules
 description: >-
   Modules are containers for multiple resources that are used together in a
   configuration. Learn when to create modules and about module structure.

--- a/website/docs/language/modules/develop/providers.mdx
+++ b/website/docs/language/modules/develop/providers.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Providers Within Modules - Configuration Language
 description: >-
   Use providers within modules. Learn about version constraints, aliases, implicit inheritance, and passing providers to modules.
 ---

--- a/website/docs/language/modules/develop/publish.mdx
+++ b/website/docs/language/modules/develop/publish.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Publishing Modules
 description: A module is a container for multiple resources that are used together.
 ---
 

--- a/website/docs/language/modules/develop/refactoring.mdx
+++ b/website/docs/language/modules/develop/refactoring.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Refactoring
 description: How to make backward-compatible changes to modules already in use.
 ---
 

--- a/website/docs/language/modules/develop/structure.mdx
+++ b/website/docs/language/modules/develop/structure.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Standard Module Structure
 description: >-
   Learn about the recommended file and directory structure for developing reusable modules distributed as separate repositories.
 ---

--- a/website/docs/language/modules/index.mdx
+++ b/website/docs/language/modules/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Modules Overview - Configuration Language
 description: >-
   Modules are containers for multiple resources that are used together in a
   configuration. Find resources for using, developing, and publishing modules.

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Module Sources
 description: >-
   The source argument tells OpenTF where to find child modules's
   configurations in locations like GitHub, the OpenTF Registry, Bitbucket,

--- a/website/docs/language/modules/syntax.mdx
+++ b/website/docs/language/modules/syntax.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Modules - Configuration Language
 description: >-
   Modules are containers for multiple resources that are used together in
   configurations. Learn how to call one module from another and access module

--- a/website/docs/language/modules/testing-experiment.mdx
+++ b/website/docs/language/modules/testing-experiment.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Module Testing Experiment - Configuration Language
 description: Part of the ongoing design research for module integration testing.
 ---
 

--- a/website/docs/language/providers/configuration.mdx
+++ b/website/docs/language/providers/configuration.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provider Configuration - Configuration Language
 description: >-
   Learn how to set up providers, including how to use the alias meta-argument to
   specify multiple configurations for a single provider.

--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Providers - Configuration Language
 description: >-
   An overview of how to install and use providers, OpenTF plugins that
   interact with services, cloud providers, and other APIs.

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provider Requirements - Configuration Language
 description: >-
   Providers are plugins that allow OpenTF to interact with services, cloud
   providers, and other APIs. Learn how to declare providers in a configuration.

--- a/website/docs/language/resources/behavior.mdx
+++ b/website/docs/language/resources/behavior.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Resource Behavior - Configuration Language
 description: >-
   Learn how OpenTF uses resource blocks to create infrastructure objects.
   Also learn about resource dependencies and how to access resource attributes.

--- a/website/docs/language/resources/index.mdx
+++ b/website/docs/language/resources/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Resources Overview - Configuration Language
 description: >-
   Resources describe infrastructure objects in OpenTF configurations. Find
   documentation for resource syntax, behavior, and meta-arguments.

--- a/website/docs/language/resources/provisioners/connection.mdx
+++ b/website/docs/language/resources/provisioners/connection.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provisioner Connection Settings
 description: >-
   The connection block allows you to manage provisioner connection defaults for
   SSH and WinRM.

--- a/website/docs/language/resources/provisioners/file.mdx
+++ b/website/docs/language/resources/provisioners/file.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Provisioner: file'
 description: >-
   The `file` provisioner is used to copy files or directories from the machine
   executing OpenTF to the newly created resource. The `file` provisioner

--- a/website/docs/language/resources/provisioners/local-exec.mdx
+++ b/website/docs/language/resources/provisioners/local-exec.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Provisioner: local-exec'
 description: >-
   The `local-exec` provisioner invokes a local executable after a resource is
   created. This invokes a process on the machine running OpenTF, not on the

--- a/website/docs/language/resources/provisioners/null_resource.mdx
+++ b/website/docs/language/resources/provisioners/null_resource.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provisioners Without a Resource
 description: >-
   A terraform_data managed resource allows you to configure provisioners that
   are not directly associated with a single existing resource.

--- a/website/docs/language/resources/provisioners/remote-exec.mdx
+++ b/website/docs/language/resources/provisioners/remote-exec.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Provisioner: remote-exec'
 description: >-
   The `remote-exec` provisioner invokes a script on a remote resource after it
   is created. This can be used to run a configuration management tool, bootstrap

--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Provisioners
 description: >-
   Provisioners run scripts on a local or remote machine during resource creation
   or destruction. Learn how to declare provisioners in a configuration.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Resources - Configuration Language
 description: >-
   Resources correspond to infrastructure objects like virtual networks or
   compute instances. Learn about resource types, syntax, behavior, and

--- a/website/docs/language/resources/tf-data.mdx
+++ b/website/docs/language/resources/tf-data.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The terraform_data Managed Resource Type
 description: >-
   Retrieves the root module output values from an OpenTF state snapshot stored
   in a remote backend.

--- a/website/docs/language/settings/backends/_category_.json
+++ b/website/docs/language/settings/backends/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Backends"
+}

--- a/website/docs/language/settings/backends/azurerm.mdx
+++ b/website/docs/language/settings/backends/azurerm.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: azurerm'
+sidebar_label: azurerm
 description: OpenTF can store state remotely in Azure Blob Storage.
 ---
 
-# azurerm
+# Backend Type: azurerm
 
 Stores the state as a Blob with the given Key within the Blob Container within [the Blob Storage Account](https://docs.microsoft.com/en-us/azure/storage/common/storage-introduction).
 

--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Backend Configuration - Configuration Language
+sidebar_position: 1
 description: >-
   Use the `backend` block to control where OpenTF stores state. Learn about the available state backends, the backend block, initializing backends, partial backend configuration, changing backend configuration, and unconfiguring a backend.
 ---

--- a/website/docs/language/settings/backends/consul.mdx
+++ b/website/docs/language/settings/backends/consul.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: consul'
+sidebar_label: consul
 description: OpenTF can store state in Consul.
 ---
 
-# consul
+# Backend Type: consul
 
 Stores the state in the [Consul](https://www.consul.io/) KV store at a given path.
 

--- a/website/docs/language/settings/backends/cos.mdx
+++ b/website/docs/language/settings/backends/cos.mdx
@@ -1,11 +1,11 @@
 ---
-page_title: 'Backend Type: cos'
+sidebar_label: cos
 description: >-
   OpenTF can store the state remotely, making it easier to version and work
   with in a team.
 ---
 
-# COS
+# Backend Type: COS
 
 Stores the state as an object in a configurable prefix in a given bucket on [Tencent Cloud Object Storage](https://intl.cloud.tencent.com/product/cos) (COS).
 

--- a/website/docs/language/settings/backends/gcs.mdx
+++ b/website/docs/language/settings/backends/gcs.mdx
@@ -1,11 +1,11 @@
 ---
-page_title: 'Backend Type: gcs'
+sidebar_label: gcs
 description: >-
   OpenTF can store the state remotely, making it easier to version and work
   with in a team.
 ---
 
-# gcs
+# Backend Type: gcs
 
 Stores the state as an object in a configurable prefix in a pre-existing bucket on [Google Cloud Storage](https://cloud.google.com/storage/) (GCS).
 The bucket must exist prior to configuring the backend.

--- a/website/docs/language/settings/backends/http.mdx
+++ b/website/docs/language/settings/backends/http.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: http'
+sidebar_label: http
 description: OpenTF can store state remotely at any valid HTTP endpoint.
 ---
 
-# http
+# Backend Type: http
 
 Stores the state using a simple [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) client.
 

--- a/website/docs/language/settings/backends/kubernetes.mdx
+++ b/website/docs/language/settings/backends/kubernetes.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: Kubernetes'
+sidebar_label: kubernetes
 description: OpenTF can store state remotely in Kubernetes and lock that state.
 ---
 
-# kubernetes
+# Backend Type: kubernetes
 
 -> **Note:** This backend is limited by Kubernetes' maximum Secret size of 1MB. See [Secret restrictions](https://kubernetes.io/docs/concepts/configuration/secret/#restrictions) for details.
 

--- a/website/docs/language/settings/backends/local.mdx
+++ b/website/docs/language/settings/backends/local.mdx
@@ -1,11 +1,11 @@
 ---
-page_title: 'Backend Type: local'
+sidebar_label: local
 description: >-
   Terraform can store the state remotely, making it easier to version and work
   with in a team.
 ---
 
-# local
+# Backend Type: local
 
 **Kind: Enhanced**
 

--- a/website/docs/language/settings/backends/oss.mdx
+++ b/website/docs/language/settings/backends/oss.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: oss'
+sidebar_label: oss
 description: OpenTF can store state remotely in OSS and lock that state with OSS.
 ---
 
-# OSS
+# Backend Type: oss
 
 Stores the state as a given key in a given bucket on Stores
 [Alibaba Cloud OSS](https://www.alibabacloud.com/help/product/31815.htm).

--- a/website/docs/language/settings/backends/pg.mdx
+++ b/website/docs/language/settings/backends/pg.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: pg'
+sidebar_label: pg
 description: OpenTF can store state remotely in a Postgres database with locking.
 ---
 
-# pg
+# Backend Type: pg
 
 Stores the state in a [Postgres database](https://www.postgresql.org) version 10 or newer.
 

--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -1,11 +1,11 @@
 ---
-page_title: 'Backend Type: remote'
+sidebar_label: remote
 description: >-
   OpenTF can store the state and run operations remotely, making it easier to
   version and work with in a team.
 ---
 
-# remote
+# Backend Type: remote
 
 -> **Note:** **We recommend using the [`cloud` built-in integration](/opentf/cli/cloud/settings)** instead of this backend. The `cloud` option includes an improved user experience and more features.
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -1,9 +1,9 @@
 ---
-page_title: 'Backend Type: s3'
+sidebar_label: s3
 description: OpenTF can store state remotely in S3 and lock that state with DynamoDB.
 ---
 
-# S3
+# Backend Type: s3
 
 Stores the state as a given key in a given bucket on
 [Amazon S3](https://aws.amazon.com/s3/).

--- a/website/docs/language/settings/index.mdx
+++ b/website/docs/language/settings/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: OpenTF Settings - Configuration Language
 description: >-
   The opentf block allows you to configure OpenTF behavior, including the
   OpenTF version, backend, integration with TACOS (TF Automation and Collaboration Software),

--- a/website/docs/language/settings/tf-cloud.mdx
+++ b/website/docs/language/settings/tf-cloud.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Cloud Configuration - OpenTF Settings - Configuration Language
 description: >-
   The nested `cloud` block configures OpenTF's integration with a cloud backend.
 ---

--- a/website/docs/language/state/backends.mdx
+++ b/website/docs/language/state/backends.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'Backends: State Storage and Locking'
 description: >-
   Backends are configured directly in OpenTF files in the `terraform`
   section.

--- a/website/docs/language/state/import.mdx
+++ b/website/docs/language/state/import.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'State: Import Existing Resources'
 description: >-
   OpenTF stores state which caches the known state of the world the last time
   OpenTF ran.

--- a/website/docs/language/state/index.mdx
+++ b/website/docs/language/state/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: State
 description: >-
   An introduction to state, information that OpenTF uses to map resources to
   a configuration, track metadata, and improve performance.

--- a/website/docs/language/state/locking.mdx
+++ b/website/docs/language/state/locking.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'State: Locking'
 description: >-
   OpenTF stores state which caches the known state of the world the last time
   OpenTF ran.

--- a/website/docs/language/state/purpose.mdx
+++ b/website/docs/language/state/purpose.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: State
 description: >-
   OpenTF must store state about your managed infrastructure and
   configuration. This state is used by OpenTF to map real world resources to

--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: The terraform_remote_state Data Source
 description: >-
   Retrieves the root module output values from an OpenTF state snapshot stored
   in a remote backend.

--- a/website/docs/language/state/remote.mdx
+++ b/website/docs/language/state/remote.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'State: Remote Storage'
 description: >-
   OpenTF can store the state remotely, making it easier to version and work
   with in a team.

--- a/website/docs/language/state/sensitive-data.mdx
+++ b/website/docs/language/state/sensitive-data.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'State: Sensitive Data'
 description: Sensitive data in OpenTF state.
 ---
 

--- a/website/docs/language/state/workspaces.mdx
+++ b/website/docs/language/state/workspaces.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: 'State: Workspaces'
 description: >-
   Workspaces allow the use of multiple states with a single configuration
   directory.

--- a/website/docs/language/syntax/configuration.mdx
+++ b/website/docs/language/syntax/configuration.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Syntax - Configuration Language
 description: >-
   Key constructs of the native OpenTF language syntax, including identifiers,
   arguments, blocks, and comments.

--- a/website/docs/language/syntax/index.mdx
+++ b/website/docs/language/syntax/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Syntax Overview - Configuration Language
 description: >-
   OpenTF language syntax for both the native and JSON variants. Also learn
   formatting conventions that you can enforce with opentf fmt.

--- a/website/docs/language/syntax/json.mdx
+++ b/website/docs/language/syntax/json.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: JSON Configuration Syntax - Configuration Language
 description: >-
   Learn about the JSON-compatible language syntax, including file structure,
   expression mapping, block mapping, and block-type-specific exceptions.

--- a/website/docs/language/syntax/style.mdx
+++ b/website/docs/language/syntax/style.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Style Conventions - Configuration Language
 description: >-
   Learn recommended formatting conventions for the OpenTF language and a
   command to automatically enforce them.

--- a/website/docs/language/upgrade-guides/index.mdx
+++ b/website/docs/language/upgrade-guides/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Upgrading to OpenTF v1.6
 description: Upgrading to OpenTF v1.6
 ---
 

--- a/website/docs/language/v1-compatibility-promises.mdx
+++ b/website/docs/language/v1-compatibility-promises.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: OpenTF v1.x Compatibility Promises
+sidebar_position: 2
 description: |-
   From OpenTF v1.6 onwards the OpenTF team promises to preserve backward
   compatibility for most of the OpenTF language and the primary CLI

--- a/website/docs/language/values/index.mdx
+++ b/website/docs/language/values/index.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Variables and Outputs
 description: >-
   An overview of input variables, output values, and local values in OpenTF
   language.

--- a/website/docs/language/values/locals.mdx
+++ b/website/docs/language/values/locals.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Local Values - Configuration Language
 description: >-
   Local values assign a name to an expression that can be used multiple times
   within a module.

--- a/website/docs/language/values/outputs.mdx
+++ b/website/docs/language/values/outputs.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Output Values - Configuration Language
 description: Output values are the return values of a module.
 ---
 

--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -1,5 +1,4 @@
 ---
-page_title: Input Variables - Configuration Language
 description: >-
   Input variables allow you to customize modules without altering their source
   code. Learn how to declare, define, and reference variables in configurations.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #422

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

This PR:
- Simplifies titles on some docs pages
- Removes 90% of duplicated page titles (they will be taken from the main headline)
- Provides title for sections that were lacking it
- Makes sure that root categories are first in a sidebar
