### PR TITLE
internal/legacy: wrap formatted errors

### DIFF
--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -102,7 +102,7 @@ func (b *Backend) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnos
 		// find a default value if it exists
 		def, err := attrSchema.DefaultValue()
 		if err != nil {
-			diags = diags.Append(fmt.Errorf("error getting default for %q: %s", getAttr.Name, err))
+			diags = diags.Append(fmt.Errorf("error getting default for %q: %w", getAttr.Name, err))
 			return val, err
 		}
 
@@ -123,7 +123,7 @@ func (b *Backend) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnos
 
 		val, err = ctyconvert.Convert(tmpVal, val.Type())
 		if err != nil {
-			diags = diags.Append(fmt.Errorf("error setting default for %q: %s", getAttr.Name, err))
+			diags = diags.Append(fmt.Errorf("error setting default for %q: %w", getAttr.Name, err))
 		}
 
 		return val, err

--- a/internal/legacy/helper/schema/field_reader_config.go
+++ b/internal/legacy/helper/schema/field_reader_config.go
@@ -254,7 +254,7 @@ func (r *ConfigFieldReader) readPrimitive(
 		var err error
 		raw, err = schema.DefaultValue()
 		if err != nil {
-			return FieldReadResult{}, fmt.Errorf("%s, error loading default: %s", k, err)
+			return FieldReadResult{}, fmt.Errorf("%s, error loading default: %w", k, err)
 		}
 
 		if raw == nil {

--- a/internal/legacy/helper/schema/field_reader_multi.go
+++ b/internal/legacy/helper/schema/field_reader_multi.go
@@ -34,7 +34,7 @@ func (r *MultiLevelFieldReader) ReadFieldExact(
 	result, err := reader.ReadField(address)
 	if err != nil {
 		return FieldReadResult{}, fmt.Errorf(
-			"Error reading level %s: %s", level, err)
+			"Error reading level %s: %w", level, err)
 	}
 
 	return result, nil
@@ -48,7 +48,7 @@ func (r *MultiLevelFieldReader) ReadFieldMerge(
 			out, err := r.ReadField(address)
 			if err != nil {
 				return FieldReadResult{}, fmt.Errorf(
-					"Error reading level %s: %s", l, err)
+					"Error reading level %s: %w", l, err)
 			}
 
 			// TODO: computed

--- a/internal/legacy/helper/schema/field_writer_map.go
+++ b/internal/legacy/helper/schema/field_writer_map.go
@@ -128,7 +128,7 @@ func (w *MapFieldWriter) setList(
 
 	var vs []interface{}
 	if err := mapstructure.Decode(v, &vs); err != nil {
-		return fmt.Errorf("%s: %s", k, err)
+		return fmt.Errorf("%s: %w", k, err)
 	}
 
 	// Wipe the set from the current writer prior to writing if it exists.
@@ -215,7 +215,7 @@ func (w *MapFieldWriter) setObject(
 	// Set the entire object. First decode into a proper structure
 	var v map[string]interface{}
 	if err := mapstructure.Decode(value, &v); err != nil {
-		return fmt.Errorf("%s: %s", strings.Join(addr, "."), err)
+		return fmt.Errorf("%s: %w", strings.Join(addr, "."), err)
 	}
 
 	// Make space for additional elements in the address
@@ -255,24 +255,24 @@ func (w *MapFieldWriter) setPrimitive(
 	case TypeBool:
 		var b bool
 		if err := mapstructure.Decode(v, &b); err != nil {
-			return fmt.Errorf("%s: %s", k, err)
+			return fmt.Errorf("%s: %w", k, err)
 		}
 
 		set = strconv.FormatBool(b)
 	case TypeString:
 		if err := mapstructure.Decode(v, &set); err != nil {
-			return fmt.Errorf("%s: %s", k, err)
+			return fmt.Errorf("%s: %w", k, err)
 		}
 	case TypeInt:
 		var n int
 		if err := mapstructure.Decode(v, &n); err != nil {
-			return fmt.Errorf("%s: %s", k, err)
+			return fmt.Errorf("%s: %w", k, err)
 		}
 		set = strconv.FormatInt(int64(n), 10)
 	case TypeFloat:
 		var n float64
 		if err := mapstructure.Decode(v, &n); err != nil {
-			return fmt.Errorf("%s: %s", k, err)
+			return fmt.Errorf("%s: %w", k, err)
 		}
 		set = strconv.FormatFloat(float64(n), 'G', -1, 64)
 	default:

--- a/internal/legacy/helper/schema/provider.go
+++ b/internal/legacy/helper/schema/provider.go
@@ -117,13 +117,13 @@ func (p *Provider) InternalValidate() error {
 
 	for k, r := range p.ResourcesMap {
 		if err := r.InternalValidate(nil, true); err != nil {
-			validationErrors = multierror.Append(validationErrors, fmt.Errorf("resource %s: %s", k, err))
+			validationErrors = multierror.Append(validationErrors, fmt.Errorf("resource %s: %w", k, err))
 		}
 	}
 
 	for k, r := range p.DataSourcesMap {
 		if err := r.InternalValidate(nil, false); err != nil {
-			validationErrors = multierror.Append(validationErrors, fmt.Errorf("data source %s: %s", k, err))
+			validationErrors = multierror.Append(validationErrors, fmt.Errorf("data source %s: %w", k, err))
 		}
 	}
 
@@ -239,7 +239,7 @@ func (p *Provider) Validate(c *opentf.ResourceConfig) ([]string, []error) {
 		return nil, []error{fmt.Errorf(
 			"Internal validation of the provider failed! This is always a bug\n"+
 				"with the provider itself, and not a user issue. Please report\n"+
-				"this bug:\n\n%s", err)}
+				"this bug:\n\n%w", err)}
 	}
 
 	return schemaMap(p.Schema).Validate(c)

--- a/internal/legacy/helper/schema/provisioner.go
+++ b/internal/legacy/helper/schema/provisioner.go
@@ -189,7 +189,7 @@ func (p *Provisioner) Validate(c *opentf.ResourceConfig) (ws []string, es []erro
 		return nil, []error{fmt.Errorf(
 			"Internal validation of the provisioner failed! This is always a bug\n"+
 				"with the provisioner itself, and not a user issue. Please report\n"+
-				"this bug:\n\n%s", err)}
+				"this bug:\n\n%w", err)}
 	}
 
 	if p.Schema != nil {

--- a/internal/legacy/helper/schema/resource.go
+++ b/internal/legacy/helper/schema/resource.go
@@ -330,7 +330,7 @@ func (r *Resource) Diff(
 	err := t.ConfigDecode(r, c)
 
 	if err != nil {
-		return nil, fmt.Errorf("[ERR] Error decoding timeout: %s", err)
+		return nil, fmt.Errorf("[ERR] Error decoding timeout: %w", err)
 	}
 
 	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.CustomizeDiff, meta, true)

--- a/internal/legacy/helper/schema/resource_diff.go
+++ b/internal/legacy/helper/schema/resource_diff.go
@@ -316,7 +316,7 @@ func (d *ResourceDiff) setDiff(key string, new interface{}, computed bool) error
 	}
 
 	if err := d.newWriter.WriteField(strings.Split(key, "."), new, computed); err != nil {
-		return fmt.Errorf("Cannot set new diff value for key %s: %s", key, err)
+		return fmt.Errorf("Cannot set new diff value for key %s: %w", key, err)
 	}
 
 	d.updatedKeys[key] = true

--- a/internal/legacy/helper/schema/resource_timeout.go
+++ b/internal/legacy/helper/schema/resource_timeout.go
@@ -114,7 +114,7 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *opentf.ResourceConfig) er
 				// Get timeout
 				rt, err := time.ParseDuration(timeValue.(string))
 				if err != nil {
-					return fmt.Errorf("Error parsing %q timeout: %s", timeKey, err)
+					return fmt.Errorf("Error parsing %q timeout: %w", timeKey, err)
 				}
 
 				var timeout *time.Duration

--- a/internal/legacy/helper/schema/schema.go
+++ b/internal/legacy/helper/schema/schema.go
@@ -328,7 +328,7 @@ func (s *Schema) DefaultValue() (interface{}, error) {
 	if s.DefaultFunc != nil {
 		defaultValue, err := s.DefaultFunc()
 		if err != nil {
-			return nil, fmt.Errorf("error loading default: %s", err)
+			return nil, fmt.Errorf("error loading default: %w", err)
 		}
 		return defaultValue, nil
 	}
@@ -648,7 +648,7 @@ func (m schemaMap) Input(
 		// Skip if it has a default value
 		defaultValue, err := v.DefaultValue()
 		if err != nil {
-			return nil, fmt.Errorf("%s: error loading default: %s", k, err)
+			return nil, fmt.Errorf("%s: error loading default: %w", k, err)
 		}
 		if defaultValue != nil {
 			continue
@@ -1047,10 +1047,10 @@ func (m schemaMap) diffMap(
 	var stateMap, configMap map[string]string
 	o, n, _, nComputed, customized := d.diffChange(k)
 	if err := mapstructure.WeakDecode(o, &stateMap); err != nil {
-		return fmt.Errorf("%s: %s", k, err)
+		return fmt.Errorf("%s: %w", k, err)
 	}
 	if err := mapstructure.WeakDecode(n, &configMap); err != nil {
-		return fmt.Errorf("%s: %s", k, err)
+		return fmt.Errorf("%s: %w", k, err)
 	}
 
 	// Keep track of whether the state _exists_ at all prior to clearing it
@@ -1281,10 +1281,10 @@ func (m schemaMap) diffString(
 		nraw = schema.Type.Zero()
 	}
 	if err := mapstructure.WeakDecode(o, &os); err != nil {
-		return fmt.Errorf("%s: %s", k, err)
+		return fmt.Errorf("%s: %w", k, err)
 	}
 	if err := mapstructure.WeakDecode(nraw, &ns); err != nil {
-		return fmt.Errorf("%s: %s", k, err)
+		return fmt.Errorf("%s: %w", k, err)
 	}
 
 	if os == ns && !all && !computed {
@@ -1347,7 +1347,7 @@ func (m schemaMap) validate(
 		raw, err = schema.DefaultFunc()
 		if err != nil {
 			return nil, []error{fmt.Errorf(
-				"%q, error loading default: %s", k, err)}
+				"%q, error loading default: %w", k, err)}
 		}
 
 		// We're okay as long as we had a value set
@@ -1616,22 +1616,22 @@ func validateMapValues(k string, m map[string]interface{}, schema *Schema) ([]st
 		case TypeBool:
 			var n bool
 			if err := mapstructure.WeakDecode(raw, &n); err != nil {
-				return nil, []error{fmt.Errorf("%s (%s): %s", k, key, err)}
+				return nil, []error{fmt.Errorf("%s (%s): %w", k, key, err)}
 			}
 		case TypeInt:
 			var n int
 			if err := mapstructure.WeakDecode(raw, &n); err != nil {
-				return nil, []error{fmt.Errorf("%s (%s): %s", k, key, err)}
+				return nil, []error{fmt.Errorf("%s (%s): %w", k, key, err)}
 			}
 		case TypeFloat:
 			var n float64
 			if err := mapstructure.WeakDecode(raw, &n); err != nil {
-				return nil, []error{fmt.Errorf("%s (%s): %s", k, key, err)}
+				return nil, []error{fmt.Errorf("%s (%s): %w", k, key, err)}
 			}
 		case TypeString:
 			var n string
 			if err := mapstructure.WeakDecode(raw, &n); err != nil {
-				return nil, []error{fmt.Errorf("%s (%s): %s", k, key, err)}
+				return nil, []error{fmt.Errorf("%s (%s): %w", k, key, err)}
 			}
 		default:
 			panic(fmt.Sprintf("Unknown validation type: %#v", schema.Type))
@@ -1753,7 +1753,7 @@ func (m schemaMap) validatePrimitive(
 		// Verify that we can parse this as the correct type
 		var n bool
 		if err := mapstructure.WeakDecode(raw, &n); err != nil {
-			return nil, []error{fmt.Errorf("%s: %s", k, err)}
+			return nil, []error{fmt.Errorf("%s: %w", k, err)}
 		}
 		decoded = n
 	case TypeInt:
@@ -1772,7 +1772,7 @@ func (m schemaMap) validatePrimitive(
 			// Verify that we can parse this as an int
 			var n int
 			if err := mapstructure.WeakDecode(raw, &n); err != nil {
-				return nil, []error{fmt.Errorf("%s: %s", k, err)}
+				return nil, []error{fmt.Errorf("%s: %w", k, err)}
 			}
 			decoded = n
 		}
@@ -1780,14 +1780,14 @@ func (m schemaMap) validatePrimitive(
 		// Verify that we can parse this as an int
 		var n float64
 		if err := mapstructure.WeakDecode(raw, &n); err != nil {
-			return nil, []error{fmt.Errorf("%s: %s", k, err)}
+			return nil, []error{fmt.Errorf("%s: %w", k, err)}
 		}
 		decoded = n
 	case TypeString:
 		// Verify that we can parse this as a string
 		var n string
 		if err := mapstructure.WeakDecode(raw, &n); err != nil {
-			return nil, []error{fmt.Errorf("%s: %s", k, err)}
+			return nil, []error{fmt.Errorf("%s: %w", k, err)}
 		}
 		decoded = n
 	default:

--- a/internal/legacy/opentf/resource_address.go
+++ b/internal/legacy/opentf/resource_address.go
@@ -212,7 +212,7 @@ func parseResourceAddressInternal(s string) (*ResourceAddress, error) {
 	if len(parts) > 2 {
 		idx, err := strconv.ParseInt(parts[2], 0, 0)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing resource address %q: %s", s, err)
+			return nil, fmt.Errorf("Error parsing resource address %q: %w", s, err)
 		}
 
 		addr.Index = int(idx)

--- a/internal/legacy/opentf/schemas.go
+++ b/internal/legacy/opentf/schemas.go
@@ -109,7 +109,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %s", name, err),
+				fmt.Errorf("Failed to instantiate provider %q to obtain schema: %w", name, err),
 			)
 			return
 		}
@@ -123,7 +123,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			// future calls.
 			schemas[fqn] = &ProviderSchema{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provider %q: %s", name, resp.Diagnostics.Err()),
+				fmt.Errorf("Failed to retrieve schema from provider %q: %w", name, resp.Diagnostics.Err()),
 			)
 			return
 		}
@@ -203,7 +203,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 			// future calls.
 			schemas[name] = &configschema.Block{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to instantiate provisioner %q to obtain schema: %s", name, err),
+				fmt.Errorf("Failed to instantiate provisioner %q to obtain schema: %w", name, err),
 			)
 			return
 		}
@@ -219,7 +219,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 			// future calls.
 			schemas[name] = &configschema.Block{}
 			diags = diags.Append(
-				fmt.Errorf("Failed to retrieve schema from provisioner %q: %s", name, resp.Diagnostics.Err()),
+				fmt.Errorf("Failed to retrieve schema from provisioner %q: %w", name, resp.Diagnostics.Err()),
 			)
 			return
 		}

--- a/internal/legacy/opentf/state.go
+++ b/internal/legacy/opentf/state.go
@@ -671,7 +671,7 @@ func (s *State) ensureHasLineage() {
 	if s.Lineage == "" {
 		lineage, err := uuid.GenerateUUID()
 		if err != nil {
-			panic(fmt.Errorf("Failed to generate lineage: %v", err))
+			panic(fmt.Errorf("Failed to generate lineage: %w", err))
 		}
 		s.Lineage = lineage
 		log.Printf("[DEBUG] New state was assigned lineage %q\n", s.Lineage)
@@ -953,7 +953,7 @@ func (s *OutputState) deepcopy() *OutputState {
 
 	stateCopy, err := copystructure.Config{Lock: true}.Copy(s)
 	if err != nil {
-		panic(fmt.Errorf("Error copying output value: %s", err))
+		panic(fmt.Errorf("Error copying output value: %w", err))
 	}
 
 	return stateCopy.(*OutputState)
@@ -1918,7 +1918,7 @@ type jsonStateVersionIdentifier struct {
 func testForV0State(buf *bufio.Reader) error {
 	start, err := buf.Peek(len("tfstate"))
 	if err != nil {
-		return fmt.Errorf("Failed to check for magic bytes: %v", err)
+		return fmt.Errorf("Failed to check for magic bytes: %w", err)
 	}
 	if string(start) == "tfstate" {
 		return fmt.Errorf("OpenTF 0.7 no longer supports upgrading the binary state\n" +
@@ -1959,12 +1959,12 @@ func ReadState(src io.Reader) (*State, error) {
 	// This is suboptimal, but will work for now.
 	jsonBytes, err := io.ReadAll(buf)
 	if err != nil {
-		return nil, fmt.Errorf("Reading state file failed: %v", err)
+		return nil, fmt.Errorf("Reading state file failed: %w", err)
 	}
 
 	versionIdentifier := &jsonStateVersionIdentifier{}
 	if err := json.Unmarshal(jsonBytes, versionIdentifier); err != nil {
-		return nil, fmt.Errorf("Decoding state file version failed: %v", err)
+		return nil, fmt.Errorf("Decoding state file version failed: %w", err)
 	}
 
 	var result *State
@@ -2034,7 +2034,7 @@ func ReadState(src io.Reader) (*State, error) {
 func ReadStateV1(jsonBytes []byte) (*stateV1, error) {
 	v1State := &stateV1{}
 	if err := json.Unmarshal(jsonBytes, v1State); err != nil {
-		return nil, fmt.Errorf("Decoding state file failed: %v", err)
+		return nil, fmt.Errorf("Decoding state file failed: %w", err)
 	}
 
 	if v1State.Version != 1 {
@@ -2048,7 +2048,7 @@ func ReadStateV1(jsonBytes []byte) (*stateV1, error) {
 func ReadStateV2(jsonBytes []byte) (*State, error) {
 	state := &State{}
 	if err := json.Unmarshal(jsonBytes, state); err != nil {
-		return nil, fmt.Errorf("Decoding state file failed: %v", err)
+		return nil, fmt.Errorf("Decoding state file failed: %w", err)
 	}
 
 	// Check the version, this to ensure we don't read a future
@@ -2083,7 +2083,7 @@ func ReadStateV2(jsonBytes []byte) (*State, error) {
 func ReadStateV3(jsonBytes []byte) (*State, error) {
 	state := &State{}
 	if err := json.Unmarshal(jsonBytes, state); err != nil {
-		return nil, fmt.Errorf("Decoding state file failed: %v", err)
+		return nil, fmt.Errorf("Decoding state file failed: %w", err)
 	}
 
 	// Check the version, this to ensure we don't read a future
@@ -2161,7 +2161,7 @@ func WriteState(d *State, dst io.Writer) error {
 	// Encode the data in a human-friendly way
 	data, err := json.MarshalIndent(d, "", "    ")
 	if err != nil {
-		return fmt.Errorf("Failed to encode state: %s", err)
+		return fmt.Errorf("Failed to encode state: %w", err)
 	}
 
 	// We append a newline to the data because MarshalIndent doesn't
@@ -2169,7 +2169,7 @@ func WriteState(d *State, dst io.Writer) error {
 
 	// Write the data out to the dst
 	if _, err := io.Copy(dst, bytes.NewReader(data)); err != nil {
-		return fmt.Errorf("Failed to write state: %v", err)
+		return fmt.Errorf("Failed to write state: %w", err)
 	}
 
 	return nil

--- a/internal/legacy/opentf/state_filter.go
+++ b/internal/legacy/opentf/state_filter.go
@@ -31,7 +31,7 @@ func (f *StateFilter) Filter(fs ...string) ([]*StateFilterResult, error) {
 	for i, v := range fs {
 		a, err := ParseResourceAddress(v)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing address '%s': %s", v, err)
+			return nil, fmt.Errorf("Error parsing address '%s': %w", v, err)
 		}
 
 		as[i] = a

--- a/internal/legacy/opentf/state_upgrade_v1_to_v2.go
+++ b/internal/legacy/opentf/state_upgrade_v1_to_v2.go
@@ -18,14 +18,14 @@ func upgradeStateV1ToV2(old *stateV1) (*State, error) {
 
 	remote, err := old.Remote.upgradeToV2()
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading State V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading State V1: %w", err)
 	}
 
 	modules := make([]*ModuleState, len(old.Modules))
 	for i, module := range old.Modules {
 		upgraded, err := module.upgradeToV2()
 		if err != nil {
-			return nil, fmt.Errorf("Error upgrading State V1: %v", err)
+			return nil, fmt.Errorf("Error upgrading State V1: %w", err)
 		}
 		modules[i] = upgraded
 	}
@@ -53,7 +53,7 @@ func (old *remoteStateV1) upgradeToV2() (*RemoteState, error) {
 
 	config, err := copystructure.Copy(old.Config)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading RemoteState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading RemoteState V1: %w", err)
 	}
 
 	return &RemoteState{
@@ -69,7 +69,7 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 
 	pathRaw, err := copystructure.Copy(old.Path)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading ModuleState V1: %w", err)
 	}
 	path, ok := pathRaw.([]string)
 	if !ok {
@@ -95,14 +95,14 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 	for key, oldResource := range old.Resources {
 		upgraded, err := oldResource.upgradeToV2()
 		if err != nil {
-			return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
+			return nil, fmt.Errorf("Error upgrading ModuleState V1: %w", err)
 		}
 		resources[key] = upgraded
 	}
 
 	dependencies, err := copystructure.Copy(old.Dependencies)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading ModuleState V1: %w", err)
 	}
 
 	return &ModuleState{
@@ -120,19 +120,19 @@ func (old *resourceStateV1) upgradeToV2() (*ResourceState, error) {
 
 	dependencies, err := copystructure.Copy(old.Dependencies)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ResourceState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading ResourceState V1: %w", err)
 	}
 
 	primary, err := old.Primary.upgradeToV2()
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading ResourceState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading ResourceState V1: %w", err)
 	}
 
 	deposed := make([]*InstanceState, len(old.Deposed))
 	for i, v := range old.Deposed {
 		upgraded, err := v.upgradeToV2()
 		if err != nil {
-			return nil, fmt.Errorf("Error upgrading ResourceState V1: %v", err)
+			return nil, fmt.Errorf("Error upgrading ResourceState V1: %w", err)
 		}
 		deposed[i] = upgraded
 	}
@@ -156,16 +156,16 @@ func (old *instanceStateV1) upgradeToV2() (*InstanceState, error) {
 
 	attributes, err := copystructure.Copy(old.Attributes)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading InstanceState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading InstanceState V1: %w", err)
 	}
 	ephemeral, err := old.Ephemeral.upgradeToV2()
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading InstanceState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading InstanceState V1: %w", err)
 	}
 
 	meta, err := copystructure.Copy(old.Meta)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading InstanceState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading InstanceState V1: %w", err)
 	}
 
 	newMeta := make(map[string]interface{})
@@ -184,7 +184,7 @@ func (old *instanceStateV1) upgradeToV2() (*InstanceState, error) {
 func (old *ephemeralStateV1) upgradeToV2() (*EphemeralState, error) {
 	connInfo, err := copystructure.Copy(old.ConnInfo)
 	if err != nil {
-		return nil, fmt.Errorf("Error upgrading EphemeralState V1: %v", err)
+		return nil, fmt.Errorf("Error upgrading EphemeralState V1: %w", err)
 	}
 	return &EphemeralState{
 		ConnInfo: connInfo.(map[string]string),


### PR DESCRIPTION
This wraps the errors in `internal/legacy` using the %w directive instead of %v or %s. I left the tests alone.

part of #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.