### PR TITLE
Missed Wrapped Errors

### DIFF
--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -164,7 +164,7 @@ func (b *Backend) path(name string) string {
 const errStateUnlock = `
 Error unlocking Azure state. Lock ID: %s
 
-Error: %s
+Error: %w
 
 You may have to force-unlock this state in order to use it again.
 `

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -99,7 +99,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	lockInfo.Operation = "init"
 	lockId, err := stateMgr.Lock(lockInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lock state in Consul: %s", err)
+		return nil, fmt.Errorf("failed to lock state in Consul: %w", err)
 	}
 
 	// Local helper function so we can call it multiple places
@@ -149,7 +149,7 @@ func (b *Backend) path(name string) string {
 const errStateUnlock = `
 Error unlocking Consul state. Lock ID: %s
 
-Error: %s
+Error: %w
 
 You may have to force-unlock this state in order to use it again.
 The Consul backend acquires a lock during initialization to ensure

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -106,7 +106,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		lockInfo.Operation = "init"
 		lockId, err := c.Lock(lockInfo)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to lock cos state: %s", err)
+			return nil, fmt.Errorf("Failed to lock cos state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -39,7 +39,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("querying Cloud Storage failed: %v", err)
+			return nil, fmt.Errorf("querying Cloud Storage failed: %w", err)
 		}
 
 		name := path.Base(attrs.Name)

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -45,7 +45,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 			TableName: b.otsTable,
 		})
 		if err != nil {
-			return client, fmt.Errorf("error describing table store %s: %#v", b.otsTable, err)
+			return client, fmt.Errorf("error describing table store %s: %w", b.otsTable, err)
 		}
 	}
 
@@ -55,7 +55,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 func (b *Backend) Workspaces() ([]string, error) {
 	bucket, err := b.ossClient.Bucket(b.bucketName)
 	if err != nil {
-		return []string{""}, fmt.Errorf("error getting bucket: %#v", err)
+		return []string{""}, fmt.Errorf("error getting bucket: %w", err)
 	}
 
 	var options []oss.Option
@@ -140,7 +140,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		lockInfo.Operation = "init"
 		lockId, err := client.Lock(lockInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to lock OSS state: %s", err)
+			return nil, fmt.Errorf("failed to lock OSS state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
@@ -193,7 +193,7 @@ const stateUnlockError = `
 Error unlocking Alibaba Cloud OSS state file:
 
 Lock ID: %s
-Error message: %#v
+Error message: %w
 
 You may have to force-unlock this state in order to use it again.
 The Alibaba Cloud backend acquires a lock during initialization to ensure the initial state file is created.

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -162,7 +162,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 		lockInfo.Operation = "init"
 		lockId, err := client.Lock(lockInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to lock s3 state: %s", err)
+			return nil, fmt.Errorf("failed to lock s3 state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places

--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -41,12 +41,12 @@ func (r *remoteClient) Get() (*remote.Payload, error) {
 			// If no state exists, then return nil.
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Error retrieving state: %v", err)
+		return nil, fmt.Errorf("Error retrieving state: %w", err)
 	}
 
 	state, err := r.client.StateVersions.Download(ctx, sv.DownloadURL)
 	if err != nil {
-		return nil, fmt.Errorf("Error downloading state: %v", err)
+		return nil, fmt.Errorf("Error downloading state: %w", err)
 	}
 
 	// If the state is empty, then return nil.
@@ -83,7 +83,7 @@ func (r *remoteClient) uploadStateFallback(ctx context.Context, stateFile *state
 	_, err := r.client.StateVersions.Create(ctx, r.workspace.ID, options)
 	if err != nil {
 		r.stateUploadErr = true
-		return fmt.Errorf("error uploading state in compatibility mode: %v", err)
+		return fmt.Errorf("error uploading state in compatibility mode: %w", err)
 	}
 	return err
 }
@@ -95,16 +95,16 @@ func (r *remoteClient) Put(state []byte) error {
 	// Read the raw state into a OpenTF state.
 	stateFile, err := statefile.Read(bytes.NewReader(state))
 	if err != nil {
-		return fmt.Errorf("error reading state: %s", err)
+		return fmt.Errorf("error reading state: %w", err)
 	}
 
 	ov, err := jsonstate.MarshalOutputs(stateFile.State.RootModule().OutputValues)
 	if err != nil {
-		return fmt.Errorf("error reading output values: %s", err)
+		return fmt.Errorf("error reading output values: %w", err)
 	}
 	o, err := json.Marshal(ov)
 	if err != nil {
-		return fmt.Errorf("error converting output values to json: %s", err)
+		return fmt.Errorf("error converting output values to json: %w", err)
 	}
 
 	options := tfe.StateVersionUploadOptions{
@@ -134,7 +134,7 @@ func (r *remoteClient) Put(state []byte) error {
 	}
 	if err != nil {
 		r.stateUploadErr = true
-		return fmt.Errorf("error uploading state: %v", err)
+		return fmt.Errorf("error uploading state: %w", err)
 	}
 
 	return nil
@@ -144,7 +144,7 @@ func (r *remoteClient) Put(state []byte) error {
 func (r *remoteClient) Delete() error {
 	err := r.client.Workspaces.Delete(context.Background(), r.organization, r.workspace.Name)
 	if err != nil && err != tfe.ErrResourceNotFound {
-		return fmt.Errorf("error deleting workspace %s: %v", r.workspace.Name, err)
+		return fmt.Errorf("error deleting workspace %s: %w", r.workspace.Name, err)
 	}
 
 	return nil

--- a/internal/cloud/backend_taskStages.go
+++ b/internal/cloud/backend_taskStages.go
@@ -177,9 +177,7 @@ func (b *Cloud) processStageOverrides(context *IntegrationContext, output Integr
 	runUrl := fmt.Sprintf(taskStageHeader, b.hostname, b.organization, context.Op.Workspace, context.Run.ID)
 	err := b.confirm(context.StopContext, context.Op, opts, context.Run, "override")
 	if err != nil && err != errRunOverridden {
-		return false, fmt.Errorf(
-			fmt.Sprintf("Failed to override: %s\n%s\n", err, runUrl),
-		)
+		return false, fmt.Errorf("Failed to override: %w\n%s\n", err, runUrl)
 	}
 
 	if err != errRunOverridden {

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -154,13 +154,13 @@ func (s *Filesystem) writeState(state *states.State, meta *SnapshotMeta) error {
 			log.Printf("[TRACE] statemgr.Filesystem: creating backup snapshot at %s", s.backupPath)
 			bfh, err := os.Create(s.backupPath)
 			if err != nil {
-				return fmt.Errorf("failed to create local state backup file: %s", err)
+				return fmt.Errorf("failed to create local state backup file: %w", err)
 			}
 			defer bfh.Close()
 
 			err = statefile.Write(s.backupFile, bfh)
 			if err != nil {
-				return fmt.Errorf("failed to write to local state backup file: %s", err)
+				return fmt.Errorf("failed to write to local state backup file: %w", err)
 			}
 
 			s.writtenBackup = true
@@ -521,7 +521,7 @@ func (s *Filesystem) lockInfo() (*LockInfo, error) {
 	info := LockInfo{}
 	err = json.Unmarshal(infoData, &info)
 	if err != nil {
-		return nil, fmt.Errorf("state file %q locked, but could not unmarshal lock info: %s", s.readPath, err)
+		return nil, fmt.Errorf("state file %q locked, but could not unmarshal lock info: %w", s.readPath, err)
 	}
 	return &info, nil
 }
@@ -535,7 +535,7 @@ func (s *Filesystem) writeLockInfo(info *LockInfo) error {
 	log.Printf("[TRACE] statemgr.Filesystem: writing lock metadata to %s", path)
 	err := os.WriteFile(path, info.Marshal(), 0600)
 	if err != nil {
-		return fmt.Errorf("could not write lock info for %q: %s", s.readPath, err)
+		return fmt.Errorf("could not write lock info for %q: %w", s.readPath, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This wraps some errors that I missed on my first pass through these packages.

`internal/backend`
`internal/cloud`
`internal/states/statemgr`

There are no user-facing changes here that warrant a CHANGELOG entry.

part of #395